### PR TITLE
Add initial desktop about page

### DIFF
--- a/src/components/AboutTitleBox.tsx
+++ b/src/components/AboutTitleBox.tsx
@@ -1,22 +1,19 @@
 import React from 'react'
-import { Box, styled, Typography } from '@material-ui/core'
+import {Box, styled, Typography} from '@material-ui/core'
 import { theme } from "../theme";
 
 
-const StyleBox = styled(Box)({
+const StyledBox = styled(Box)({
   margin: 'auto',
-  width: '42.5rem',
+  width: '100%',
   height: '38.25rem',
-  padding: '4.313rem 11.875rem 4.125rem 1.75rem',
   background: 'transparent',
-  boxSizing: 'border-box',
+  boxSizing: 'border-box'
 });
 
-const StyleText = styled(Typography)({
-  width: '36.875rem',
-  height: '17.938rem',
-  margin: 0,
-  padding: 0,
+const StyledText = styled(Typography)({
+  maxWidth: '36rem',
+  padding: '4.3rem 1.75rem',
   fontFamily: theme.typography.fontFamily,
   fontSize: '3.25rem',
   fontWeight: 600,
@@ -34,8 +31,8 @@ interface Props {
 
 export const AboutTitleBox: React.FC<Props> = (props: Props) => {
   return (
-    <StyleBox>
-      <StyleText>{props.text}</StyleText>
-    </StyleBox>
+    <StyledBox>
+      <StyledText>{props.text}</StyledText>
+    </StyledBox>
   );
 }

--- a/src/components/AboutTitleBox.tsx
+++ b/src/components/AboutTitleBox.tsx
@@ -27,11 +27,12 @@ const StyledText = styled(Typography)({
 
 interface Props {
   text: string;
+  classes?: string;
 }
 
 export const AboutTitleBox: React.FC<Props> = (props: Props) => {
   return (
-    <StyledBox>
+    <StyledBox className={props.classes}>
       <StyledText>{props.text}</StyledText>
     </StyledBox>
   );

--- a/src/components/CloseBox.tsx
+++ b/src/components/CloseBox.tsx
@@ -1,24 +1,21 @@
 import React from 'react'
-import { Box, styled, Typography, Grid } from '@material-ui/core'
+import {Box, styled, Typography, Grid, useMediaQuery, useTheme, Theme} from '@material-ui/core'
 import { theme } from "../theme";
 import { CloseButton } from "./CloseButton";
 
 
-const StyleBox = styled(Box)({
+const StyledBox = styled(Box)({
   margin: 'auto',
-  width: '85rem',
-  height: '14.563rem',
-  padding: '0 0 0 5rem',
+  width: '100%',
+  height: '14.6rem',
   background: theme.palette.secondary.main,
   boxSizing: 'border-box',
   position: 'relative'
 });
 
-const StyleQuote = styled(Typography)({
-  width: '33.25rem',
+const StyledQuote = styled(Typography)({
+  maxWidth: '31rem',
   height: '6.375rem',
-  margin: '2.3rem 15.312rem 1.938rem 0',
-  padding: 0,
   fontFamily: theme.typography.fontFamily,
   fontSize: '2.25rem',
   fontWeight: 300,
@@ -30,11 +27,10 @@ const StyleQuote = styled(Typography)({
   color: theme.palette.text.primary
 });
 
-const StyleCitation = styled(Typography)({
+const StyledCitation = styled(Typography)({
   width: '100%',
   height: '1.25rem',
-  margin: '1.25rem 0 2.563rem 0',
-  padding: 0,
+  margin: '2rem 0 0 0',
   fontFamily: theme.typography.fontFamily,
   fontSize: '1.125rem',
   fontWeight: 500,
@@ -46,19 +42,18 @@ const StyleCitation = styled(Typography)({
   color: theme.palette.text.primary
 });
 
-const StyleIcon = styled('img')({
-  width: '5.626rem',
-  height: '3.917rem',
-  margin: '4.25rem 4.937rem 3.02rem 0',
+const StyledIcon = styled('img')({
+  width: '5.6rem',
+  height: '3.9rem',
+  margin: '1rem',
   objectFit: "contain",
-  float: 'left'
+  position: 'relative',
+  bottom: '1.6rem'
 });
 
-const StyleRings = styled('img')({
-  width: '13.524rem',
-  height: '13.683rem',
-  margin: '0',
-  padding: '0',
+const StyledRings = styled('img')({
+  width: '13.5rem',
+  height: '13.7rem',
   objectFit: 'contain',
   transform: 'scaleX(-1)',
   position: 'absolute',
@@ -74,23 +69,37 @@ interface Props {
 }
 
 export const CloseBox: React.FC<Props> = (props: Props) => {
+
+  const theme: Theme = useTheme();
+  const extraLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+
   return (
-    <StyleBox>
-      <Grid container direction='row' justify='flex-start' alignItems='flex-start' style={{height: 'inherit'}}>
-        <Grid item>
-          <StyleIcon src='imgs/quotation-mark-icon.svg' alt={'quotation mark icon'} />
-        </Grid>
-        <Grid item>
-          <StyleQuote><strong>“</strong>{props.quote}<strong>”</strong></StyleQuote>
-          <StyleCitation>{props.citation}</StyleCitation>
-        </Grid>
-        <Grid item style={{height: 'inherit'}}>
-          <Grid container direction='row' justify='flex-start' alignItems='center' style={{height: 'inherit'}}>
+    <StyledBox>
+      <Grid container spacing={0} direction='row' justify='flex-start' alignItems='flex-start' style={{height: 'inherit'}}>
+        {extraLargeScreen &&
+        (<Grid container item xs={8} lg={7} xl={6} spacing={0} direction='row' justify='space-evenly' alignItems='center' style={{height: 'inherit'}}>
+          <Grid item>
+            <StyledIcon src='imgs/quotation-mark-icon.svg' alt={'quotation mark icon'} />
+          </Grid>
+          <Grid item>
+            <StyledQuote><strong>“</strong>{props.quote}<strong>”</strong></StyledQuote>
+            <StyledCitation>{props.citation}</StyledCitation>
+          </Grid>
+        </Grid>)}
+        {!extraLargeScreen &&
+        (<Grid container item xs={8} lg={7} xl={6} spacing={0} direction='row' justify='space-evenly' alignItems='center' style={{height: 'inherit'}}>
+          <Grid item>
+            <StyledQuote><strong>“</strong>{props.quote}<strong>”</strong></StyledQuote>
+            <StyledCitation>{props.citation}</StyledCitation>
+          </Grid>
+        </Grid>)}
+        <Grid item xs={4} lg={5} xl={6} container direction='row' justify='center' alignItems='center' style={{height: 'inherit'}}>
+          <Grid item>
             <CloseButton text={props.buttonText} handleClick={props.onButtonClick} />
           </Grid>
         </Grid>
       </Grid>
-      <StyleRings src='imgs/concentric-rings-right.svg' alt={'concentric rings flourish'} />
-    </StyleBox>
+      <StyledRings src='imgs/concentric-rings-right.svg' alt={'concentric rings flourish'} />
+    </StyledBox>
   );
 }

--- a/src/components/CloseBox.tsx
+++ b/src/components/CloseBox.tsx
@@ -66,6 +66,7 @@ interface Props {
   citation: string;
   buttonText: string;
   onButtonClick: () => void;
+  classes?: string;
 }
 
 export const CloseBox: React.FC<Props> = (props: Props) => {
@@ -74,7 +75,7 @@ export const CloseBox: React.FC<Props> = (props: Props) => {
   const extraLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
 
   return (
-    <StyledBox>
+    <StyledBox className={props.classes}>
       <Grid container spacing={0} direction='row' justify='flex-start' alignItems='flex-start' style={{height: 'inherit'}}>
         {extraLargeScreen &&
         (<Grid container item xs={8} lg={7} xl={6} spacing={0} direction='row' justify='space-evenly' alignItems='center' style={{height: 'inherit'}}>

--- a/src/components/LeftMargin.tsx
+++ b/src/components/LeftMargin.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { styled, Grid } from '@material-ui/core'
+
+const StyledGrid = styled(Grid)({
+  height: '116.775rem',
+  width: '100%',
+  maxWidth: '7.5vw'
+});
+
+const CenterLine = styled('div')({
+  width: 'inherit',
+  height: '57.25rem'
+});
+
+interface Props {
+  xs: boolean | "auto" | 10 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 11 | 12 | undefined;
+  border?: string;
+  centerLine?: string;
+}
+
+export const LeftMargin: React.FC<Props> = (props: Props) => {
+
+  return (
+    <StyledGrid item xs={props.xs} className={props.border}>
+      <CenterLine style={{borderBottom: props.centerLine}}/>
+    </StyledGrid>
+  );
+}

--- a/src/components/LeftMargin.tsx
+++ b/src/components/LeftMargin.tsx
@@ -1,28 +1,29 @@
 import React from 'react'
-import { styled, Grid } from '@material-ui/core'
+import {styled, Grid, useTheme, Theme, useMediaQuery} from '@material-ui/core'
 
 const StyledGrid = styled(Grid)({
-  height: '116.775rem',
-  width: '100%',
-  maxWidth: '7.5vw'
+  maxWidth: '8vw'
 });
 
-const CenterLine = styled('div')({
+// It's a little weird using a grid here, but doing so correctly lines up box borders
+const CenterLine = styled(Grid)({
   width: 'inherit',
-  height: '57.25rem'
+  height: '57.375rem',
 });
 
 interface Props {
   xs: boolean | "auto" | 10 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 11 | 12 | undefined;
   border?: string;
-  centerLine?: string;
 }
 
 export const LeftMargin: React.FC<Props> = (props: Props) => {
 
+  const theme: Theme = useTheme();
+  const largeScreen = useMediaQuery(theme.breakpoints.up('lg'));
+
   return (
-    <StyledGrid item xs={props.xs} className={props.border}>
-      <CenterLine style={{borderBottom: props.centerLine}}/>
+    <StyledGrid item xs={props.xs} style={{height: largeScreen ? '116.775rem' : '202.75rem'}}>
+      <CenterLine item style={{borderBottom: props.border}} />
     </StyledGrid>
   );
 }

--- a/src/components/PitchBox.tsx
+++ b/src/components/PitchBox.tsx
@@ -13,7 +13,9 @@ const StyledGrid = styled(Grid)({
   boxSizing: 'border-box',
   '&:hover': {
     backgroundColor: hexToRGB(theme.palette.secondary.main, 0.15)
-  }
+  },
+  position: 'relative',
+  zIndex: 2
 });
 
 const StyledDetail = styled(Typography)({

--- a/src/components/PitchBox.tsx
+++ b/src/components/PitchBox.tsx
@@ -56,6 +56,7 @@ const StyledIcon = styled('img')({
 
 interface Props {
     pitch: Pitch;
+    classes?: string;
 }
 
 export const PitchBox: React.FC<Props> = (props: Props) => {
@@ -65,7 +66,7 @@ export const PitchBox: React.FC<Props> = (props: Props) => {
 
   if (extraLargeScreen) {
     return (
-      <StyledGrid container direction='row' spacing={0} justify='flex-start' alignItems='center'>
+      <StyledGrid className={props.classes} container direction='row' spacing={0} justify='flex-start' alignItems='center'>
         <Grid item xs={12} sm={2}>
           <StyledIcon src={props.pitch.icon} alt='icon' />
         </Grid>
@@ -77,7 +78,7 @@ export const PitchBox: React.FC<Props> = (props: Props) => {
     );
   } else {
     return (
-      <StyledGrid container direction='row' spacing={0} justify='flex-start' alignItems='center' style={{padding: '4% 3.375%'}}>
+      <StyledGrid className={props.classes} container direction='row' spacing={0} justify='flex-start' alignItems='center' style={{padding: '4% 3.375%'}}>
         <Grid item xs={12} sm={2}>
           <StyledIcon src={props.pitch.icon} alt='icon' style={{margin: 0, marginBottom: '1rem'}} />
         </Grid>

--- a/src/components/PitchBox.tsx
+++ b/src/components/PitchBox.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
-import { Box, styled, Typography, Grid } from '@material-ui/core'
+import {styled, Typography, Grid, useMediaQuery, useTheme, Theme} from '@material-ui/core'
 import { theme } from "../theme";
 import {Pitch} from "../constants/pitches";
 import {hexToRGB} from "../utils";
 
-const StyleBox = styled(Box)({
+const StyledGrid = styled(Grid)({
   margin: 'auto',
-  width: '42.5rem',
-  height: '14.313rem',
-  padding: '3.813rem 8.75rem 4.125rem 2.875rem',
+  width: '100%',
+  height: '14.3rem',
+  padding: '9% 6.75%',
   backgroundColor: 'rgba(0, 0, 0, 0.15)',
   boxSizing: 'border-box',
   '&:hover': {
@@ -16,10 +16,10 @@ const StyleBox = styled(Box)({
   }
 });
 
-const StyleDetail = styled(Typography)({
+const StyledDetail = styled(Typography)({
   width: '24rem',
-  height: '2.813rem',
-  margin: '1.25rem 0 0 2.313rem',
+  height: '2.8rem',
+  margin: '1.25rem 0 0 0',
   fontFamily: theme.typography.fontFamily,
   fontSize: '0.938rem',
   fontWeight: 500,
@@ -31,10 +31,9 @@ const StyleDetail = styled(Typography)({
   color: theme.palette.text.secondary
 });
 
-const StylePitch = styled(Typography)({
+const StyledPitch = styled(Typography)({
   width: '100%',
   height: '100%',
-  margin: '0 0 0 2.313rem',
   fontFamily: theme.typography.fontFamily,
   fontSize: '2rem',
   fontWeight: 600,
@@ -46,10 +45,11 @@ const StylePitch = styled(Typography)({
   color: theme.palette.text.primary
 });
 
-const StyleIcon = styled('img')({
+const StyledIcon = styled('img')({
   width: "3.75rem",
   height: "3.75rem",
-  margin: '0 0 0 0',
+  marginRight: '2.3rem',
+  marginBottom: '3rem',
   objectFit: "contain",
   float: 'left'
 });
@@ -59,17 +59,33 @@ interface Props {
 }
 
 export const PitchBox: React.FC<Props> = (props: Props) => {
-  return (
-    <StyleBox>
-      <Grid container direction='row' spacing={0} justify='flex-start' alignItems='flex-start'>
-        <Grid item>
-          <StyleIcon src={props.pitch.icon} alt='icon' />
+
+  const theme: Theme = useTheme();
+  const extraLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+
+  if (extraLargeScreen) {
+    return (
+      <StyledGrid container direction='row' spacing={0} justify='flex-start' alignItems='center'>
+        <Grid item xs={12} sm={2}>
+          <StyledIcon src={props.pitch.icon} alt='icon' />
         </Grid>
-        <Grid item>
-          <StylePitch>{props.pitch.pitch}</StylePitch>
-          <StyleDetail>{props.pitch.detail}</StyleDetail>
+        <Grid item xs={12} sm={10}>
+          <StyledPitch>{props.pitch.pitch}</StyledPitch>
+          <StyledDetail>{props.pitch.detail}</StyledDetail>
         </Grid>
-      </Grid>
-    </StyleBox>
-  );
+      </StyledGrid>
+    );
+  } else {
+    return (
+      <StyledGrid container direction='row' spacing={0} justify='flex-start' alignItems='center' style={{padding: '4% 3.375%'}}>
+        <Grid item xs={12} sm={2}>
+          <StyledIcon src={props.pitch.icon} alt='icon' style={{margin: 0, marginBottom: '1rem'}} />
+        </Grid>
+        <Grid item xs={12} sm={10}>
+          <StyledPitch>{props.pitch.pitch}</StyledPitch>
+          <StyledDetail>{props.pitch.detail}</StyledDetail>
+        </Grid>
+      </StyledGrid>
+    );
+  }
 }

--- a/src/components/PitchTitleBox.tsx
+++ b/src/components/PitchTitleBox.tsx
@@ -33,11 +33,21 @@ const StyledRings = styled('img')({
   top: 0,
   right: 0,
   zIndex: 1
-})
+});
+
+const Accent = styled('div')({
+  height: '5rem',
+  position: 'absolute',
+  top: 0,
+  left: '50%',
+  right: '50%'
+});
+
 
 interface Props {
   text: string;
   classes?: string;
+  accentStyle?: string;
 }
 
 export const PitchTitleBox: React.FC<Props> = (props: Props) => {
@@ -47,6 +57,7 @@ export const PitchTitleBox: React.FC<Props> = (props: Props) => {
         <StyledText>{props.text}</StyledText>
       </Grid>
       <StyledRings src='imgs/concentric-rings-left.svg' alt={'concentric rings flourish'} />
+      <Accent style={{borderRight: props.accentStyle}} />
     </StyledGrid>
   );
 }

--- a/src/components/PitchTitleBox.tsx
+++ b/src/components/PitchTitleBox.tsx
@@ -40,7 +40,8 @@ const Accent = styled('div')({
   position: 'absolute',
   top: 0,
   left: '50%',
-  right: '50%'
+  right: '50%',
+  zIndex: 2
 });
 
 

--- a/src/components/PitchTitleBox.tsx
+++ b/src/components/PitchTitleBox.tsx
@@ -1,23 +1,19 @@
 import React from 'react'
-import { Box, styled, Typography, } from '@material-ui/core'
+import {Grid, styled, Typography,} from '@material-ui/core'
 import { theme } from "../theme";
 
 
-const StyleBox = styled(Box)({
+const StyledGrid = styled(Grid)({
   margin: 'auto',
-  width: '85rem',
+  width: '100%',
   height: '16.2rem',
-  padding: '6.188rem 0 6.313rem 1.8rem',
   background: 'transparent',
   boxSizing: 'border-box',
   position: 'relative'
 });
 
-const StyleText = styled(Typography)({
-  width: '59.438rem',
-  height: '3.688rem',
-  margin: 0,
-  padding: 0,
+const StyledText = styled(Typography)({
+  marginLeft: '1.8rem',
   fontFamily: theme.typography.fontFamily,
   fontSize: '3.25rem',
   fontWeight: 600,
@@ -29,11 +25,9 @@ const StyleText = styled(Typography)({
   color: theme.palette.text.primary
 });
 
-const StyleRings = styled('img')({
+const StyledRings = styled('img')({
   width: '19.125rem',
   height: '19.063rem',
-  margin: '0',
-  padding: '0',
   objectFit: 'contain',
   position: 'absolute',
   top: 0,
@@ -47,9 +41,11 @@ interface Props {
 
 export const PitchTitleBox: React.FC<Props> = (props: Props) => {
   return (
-    <StyleBox>
-      <StyleText>{props.text}</StyleText>
-      <StyleRings src='imgs/concentric-rings-left.svg' alt={'concentric rings flourish'} />
-    </StyleBox>
+    <StyledGrid container alignItems='center'>
+      <Grid item>
+        <StyledText>{props.text}</StyledText>
+      </Grid>
+      <StyledRings src='imgs/concentric-rings-left.svg' alt={'concentric rings flourish'} />
+    </StyledGrid>
   );
 }

--- a/src/components/PitchTitleBox.tsx
+++ b/src/components/PitchTitleBox.tsx
@@ -37,11 +37,12 @@ const StyledRings = styled('img')({
 
 interface Props {
   text: string;
+  classes?: string;
 }
 
 export const PitchTitleBox: React.FC<Props> = (props: Props) => {
   return (
-    <StyledGrid container alignItems='center'>
+    <StyledGrid className={props.classes} container alignItems='center'>
       <Grid item>
         <StyledText>{props.text}</StyledText>
       </Grid>

--- a/src/components/PressBox.tsx
+++ b/src/components/PressBox.tsx
@@ -42,11 +42,12 @@ const StyledRings = styled('img')({
 
 interface Props {
   press: Press;
+  classes?: string;
 }
 
 export const PressBox: React.FC<Props> = (props: Props) => {
   return (
-    <StyledBox>
+    <StyledBox className={props.classes}>
       <StyledRings src='imgs/concentric-rings-right.svg' alt={'concentric rings flourish'} />
       <StyledGrid container direction='row' spacing={0} justify='center' alignItems='center'>
         {Object.values(props.press).map((article: Article, index: number) => (

--- a/src/components/PressBox.tsx
+++ b/src/components/PressBox.tsx
@@ -3,29 +3,25 @@ import { Box, styled, Grid } from '@material-ui/core'
 import { theme } from "../theme";
 import {Article, Press} from "../constants/press";
 
-const BOX_WIDTH = 42.5;
-const BOX_HEIGHT = 19.125;
-const PADDING = 2;
 
-const StyleBox = styled(Box)({
+const StyledBox = styled(Box)({
   margin: 'auto',
-  width: BOX_WIDTH.toString() + 'rem',
-  height: BOX_HEIGHT.toString() + 'rem',
-  padding: PADDING.toString() + 'rem 0',
+  width: '100%',
+  height: '19.125rem',
+  padding: '4.7% 0',
   backgroundColor: theme.palette.secondary.main,
   boxSizing: 'border-box',
   position: 'relative'
 });
 
-const StyleGrid = styled(Grid)({
-  width: BOX_WIDTH.toString() + 'rem',
-  height: (BOX_HEIGHT - 2*PADDING).toString() + 'rem',
+const StyledGrid = styled(Grid)({
+  width: '100%',
+  height: '100%',
 });
 
-const StyleIcon = styled('img')({
+const StyledIcon = styled('img')({
   width: "12.5rem",
-  height: "100%",
-  maxHeight: '3rem',
+  height: "3rem",
   margin: 'auto',
   objectFit: "contain",
   background: 'transparent',
@@ -34,11 +30,9 @@ const StyleIcon = styled('img')({
   zIndex: 2
 });
 
-const StyleRings = styled('img')({
+const StyledRings = styled('img')({
   width: '14.313rem',
   height: '14.5rem',
-  margin: '0',
-  padding: '0',
   objectFit: 'contain',
   position: 'absolute',
   top: 0,
@@ -52,17 +46,17 @@ interface Props {
 
 export const PressBox: React.FC<Props> = (props: Props) => {
   return (
-    <StyleBox>
-      <StyleRings src='imgs/concentric-rings-right.svg' alt={'concentric rings flourish'} />
-      <StyleGrid container direction='row' spacing={0} justify='center' alignItems='center'>
+    <StyledBox>
+      <StyledRings src='imgs/concentric-rings-right.svg' alt={'concentric rings flourish'} />
+      <StyledGrid container direction='row' spacing={0} justify='center' alignItems='center'>
         {Object.values(props.press).map((article: Article, index: number) => (
           <Grid item xs={6} key={`article-${index}`}>
             <a href={article.url} target='_blank' rel='noopener noreferrer'>
-              <StyleIcon src={article.logo} srcSet={article.logo + ' 1x, ' + article.logo2x + ' 2x, ' + article.logo3x + ' 3x'} alt='icon' />
+              <StyledIcon src={article.logo} srcSet={article.logo + ' 1x, ' + article.logo2x + ' 2x, ' + article.logo3x + ' 3x'} alt='icon' />
             </a>
           </Grid>
         ))}
-      </StyleGrid>
-    </StyleBox>
+      </StyledGrid>
+    </StyledBox>
   );
 }

--- a/src/components/RightMargin.tsx
+++ b/src/components/RightMargin.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
-import { styled, Grid } from '@material-ui/core'
+import {styled, Grid, useTheme, Theme, useMediaQuery} from '@material-ui/core'
 import {theme} from "../theme";
 
 const StyledGrid = styled(Grid)({
   height: '116.775rem',
-  maxWidth: '7.5vw'
+  maxWidth: '8vw'
 });
 
-const CenterLine = styled('div')({
+const CenterLine = styled(Grid)({
   width: 'inherit',
-  height: '57.25rem',
+  height: '57.375rem',
 });
 
 const RectangleAccentPrimary = styled('div')({
@@ -30,22 +30,30 @@ const RectangleAccentSecondary = styled('div')({
 interface Props {
   xs: boolean | "auto" | 10 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 11 | 12 | undefined;
   border?: string;
-  centerLine?: string;
+}
+
+const Accents: React.FC<Props> = (props: Props) => {
+  return (
+    <CenterLine container direction={'column'} justify={'center'} alignItems={'center'} style={{borderBottom: props.border}}>
+      <RectangleAccentPrimary />
+      <RectangleAccentSecondary />
+      <RectangleAccentPrimary />
+      <RectangleAccentPrimary />
+      <RectangleAccentPrimary />
+    </CenterLine>
+  );
 }
 
 export const RightMargin: React.FC<Props> = (props: Props) => {
+
+  const theme: Theme = useTheme();
+  const largeScreen = useMediaQuery(theme.breakpoints.up('lg'));
+
   return (
-    <StyledGrid item xs={props.xs} className={props.border}>
-      <Grid item container xs={12} direction={'column'} justify={'center'} alignItems={'center'} style={{height: '57.25rem'}}>
-        <RectangleAccentPrimary />
-        <RectangleAccentSecondary />
-        <RectangleAccentPrimary />
-        <RectangleAccentPrimary />
-        <RectangleAccentPrimary />
-      </Grid>
-      <Grid item xs={12} style={{width: 'inherit'}}>
-        <CenterLine style={{borderTop: props.centerLine}} />
-      </Grid>
+    <StyledGrid item xs={props.xs} style={{borderLeft: props.border, height: largeScreen ? '116.775rem' : '202.75rem'}}>
+      {largeScreen ?
+        <Accents xs={props.xs} border={props.border}/> :
+        <CenterLine container direction={'column'} justify={'center'} alignItems={'center'} style={{borderBottom: props.border}} />}
     </StyledGrid>
   );
 }

--- a/src/components/RightMargin.tsx
+++ b/src/components/RightMargin.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { styled, Grid } from '@material-ui/core'
+import {theme} from "../theme";
+
+const StyledGrid = styled(Grid)({
+  height: '116.775rem',
+  maxWidth: '7.5vw'
+});
+
+const CenterLine = styled('div')({
+  width: 'inherit',
+  height: '57.25rem',
+});
+
+const RectangleAccentPrimary = styled('div')({
+  width: '1.625rem',
+  height: '0.125rem',
+  marginTop: '1.125rem',
+  opacity: '0.6',
+  backgroundColor: theme.palette.text.primary
+});
+
+const RectangleAccentSecondary = styled('div')({
+  width: '2.875rem',
+  height: '0.125rem',
+  marginTop: '1.125rem',
+  backgroundColor: theme.palette.text.secondary
+});
+
+interface Props {
+  xs: boolean | "auto" | 10 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 11 | 12 | undefined;
+  border?: string;
+  centerLine?: string;
+}
+
+export const RightMargin: React.FC<Props> = (props: Props) => {
+  return (
+    <StyledGrid item xs={props.xs} className={props.border}>
+      <Grid item container xs={12} direction={'column'} justify={'center'} alignItems={'center'} style={{height: '57.25rem'}}>
+        <RectangleAccentPrimary />
+        <RectangleAccentSecondary />
+        <RectangleAccentPrimary />
+        <RectangleAccentPrimary />
+        <RectangleAccentPrimary />
+      </Grid>
+      <Grid item xs={12} style={{width: 'inherit'}}>
+        <CenterLine style={{borderTop: props.centerLine}} />
+      </Grid>
+    </StyledGrid>
+  );
+}

--- a/src/components/StatBox.tsx
+++ b/src/components/StatBox.tsx
@@ -4,11 +4,11 @@ import { Box, styled, Typography, Grid } from '@material-ui/core'
 import { Stat } from "../constants/stats";
 import { theme } from "../theme";
 
-const StyleBox = styled(Box)({
+const StyledBox = styled(Box)({
   margin: 'auto',
-  width: '21.25rem',
+  width: '100%',
   height: '19.125rem',
-  padding: '1.75rem 1.75rem 1.75rem 1.75rem',
+  padding: '1.75rem',
   backgroundColor: 'transparent',
   boxSizing: 'border-box',
   '&:hover': {
@@ -16,10 +16,9 @@ const StyleBox = styled(Box)({
   }
 });
 
-const StyleTitle = styled(Typography)({
+const StyledTitle = styled(Typography)({
   width: '100%',
   height: '100%',
-  margin: '1.938rem 0 0 0',
   fontFamily: theme.typography.fontFamily,
   fontSize: '0.938rem',
   fontWeight: 'bold',
@@ -31,10 +30,10 @@ const StyleTitle = styled(Typography)({
   color: theme.palette.text.secondary
 });
 
-const StyleStat = styled(Typography)({
+const StyledStat = styled(Typography)({
   width: "100%",
   height: "100%",
-  margin: "0 0 1.938rem 0",
+  margin: '0 0 1.938rem 0',
   fontFamily: theme.typography.fontFamily,
   fontSize: "3.25rem",
   fontWeight: "bold",
@@ -46,10 +45,10 @@ const StyleStat = styled(Typography)({
   color: theme.palette.text.primary
 });
 
-const StyleIcon = styled('img')({
+const StyledIcon = styled('img')({
   width: "1.5rem",
   height: "1.5rem",
-  margin: '0 0 3.5rem 1.625rem',
+  margin: '0 0 3.5rem 0',
   objectFit: "contain",
   float: 'right'
 });
@@ -60,14 +59,12 @@ interface Props {
 
 export const StatBox: React.FC<Props> = (props: Props) => {
   return (
-    <StyleBox>
-      <StyleIcon src={props.stat.icon} alt='icon' />
+    <StyledBox>
+      <StyledIcon src={props.stat.icon} alt='icon' />
       <Grid container direction='column' spacing={0} justify='center' alignItems='center'>
-        <div>
-          <StyleStat>{props.stat.stat}</StyleStat>
-          <StyleTitle>{props.stat.title}</StyleTitle>
-        </div>
+        <StyledStat>{props.stat.stat}</StyledStat>
+        <StyledTitle>{props.stat.title}</StyledTitle>
       </Grid>
-    </StyleBox>
+    </StyledBox>
   );
 }

--- a/src/components/StatBox.tsx
+++ b/src/components/StatBox.tsx
@@ -55,11 +55,12 @@ const StyledIcon = styled('img')({
 
 interface Props {
   stat: Stat;
+  classes?: string;
 }
 
 export const StatBox: React.FC<Props> = (props: Props) => {
   return (
-    <StyledBox>
+    <StyledBox className={props.classes}>
       <StyledIcon src={props.stat.icon} alt='icon' />
       <Grid container direction='column' spacing={0} justify='center' alignItems='center'>
         <StyledStat>{props.stat.stat}</StyledStat>

--- a/src/components/ZepBox.tsx
+++ b/src/components/ZepBox.tsx
@@ -1,4 +1,4 @@
-import { styled, useTheme, Box } from '@material-ui/core'
+import { styled, Box } from '@material-ui/core'
 import React from 'react'
 
 const StyleBox = styled(Box)({
@@ -8,8 +8,7 @@ const StyleBox = styled(Box)({
 });
 
 export const ZepBox: React.FC = () => {
-  const theme = useTheme()
-  
+
   return (
     <StyleBox>
       <h1>test</h1>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -54,6 +54,10 @@ const useBorders = makeStyles({
   },
   bottomBorder: {
     borderBottom: borderStyle
+  },
+  bottomLeftBorder: {
+    borderBottom: borderStyle,
+    borderLeft: borderStyle
   }
 });
 
@@ -66,34 +70,34 @@ export const About: React.FC = () => {
 
   return (
     <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
-      <LeftMargin xs={1} border={borders.allBorders} centerLine={borderStyle}/>
+      <LeftMargin xs={1} border={borderStyle} />
       <ContentContainer container item xs={10} spacing={0} direction='row' justify="center" alignItems='flex-start'>
         <Grid item xs={12} lg={6}>
-          <AboutTitleBox text={ABOUT_TITLE} classes={borders.allBorders} />
-          <PressBox press={press} classes={borders.allBorders} />
+          <AboutTitleBox text={ABOUT_TITLE} classes={borders.bottomLeftBorder} />
+          <PressBox press={press} classes={borders.bottomLeftBorder} />
         </Grid>
         <StatsContainer container item xs={12} lg={6} spacing={0} justify="center">
           {Object.values(stats).map((stat: Stat, index: number) => (
             <Grid item xs={6} key={`stat-${index}`}>
-              <StatBox stat={stat} classes={borders.allBorders} />
+              <StatBox stat={stat} classes={borders.bottomLeftBorder} />
             </Grid>
           ))}
         </StatsContainer>
         <Grid item xs={12}>
-          <PitchTitleBox text={PITCHES_TITLE} classes={borders.allBorders} />
+          <PitchTitleBox text={PITCHES_TITLE} classes={borders.bottomLeftBorder} />
         </Grid>
         <PitchesContainer container item xs={12} spacing={0} justify="center">
           {Object.values(pitches).map((pitch: Pitch, index: number) => (
             <Grid item xs={12} lg={6} key={`pitch-${index}`}>
-              <PitchBox pitch={pitch} classes={borders.allBorders} />
+              <PitchBox pitch={pitch} classes={borders.bottomLeftBorder} />
             </Grid>
           ))}
         </PitchesContainer>
         <Grid item xs={12}>
-          <CloseBox quote={QUOTE_TEXT} citation={QUOTE_CITATION} buttonText={CLOSE_BUTTON_TEXT} onButtonClick={navigateToContactPage} classes={borders.allBorders} />
+          <CloseBox quote={QUOTE_TEXT} citation={QUOTE_CITATION} buttonText={CLOSE_BUTTON_TEXT} onButtonClick={navigateToContactPage} classes={borders.leftBorder} />
         </Grid>
       </ContentContainer>
-      <RightMargin xs={1} border={borders.allBorders} centerLine={borderStyle} />
+      <RightMargin xs={1} border={borderStyle} />
     </Root>
   );
 }

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -84,7 +84,7 @@ export const About: React.FC = () => {
           ))}
         </StatsContainer>
         <Grid item xs={12}>
-          <PitchTitleBox text={PITCHES_TITLE} classes={borders.bottomLeftBorder} />
+          <PitchTitleBox text={PITCHES_TITLE} classes={borders.bottomLeftBorder} accentStyle={borderStyle} />
         </Grid>
         <PitchesContainer container item xs={12} spacing={0} justify="center">
           {Object.values(pitches).map((pitch: Pitch, index: number) => (

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useHistory } from 'react-router-dom'
-import { Box, Grid, styled } from "@material-ui/core";
+import { Grid, styled } from "@material-ui/core";
 import { StatBox } from "../components/StatBox";
 import { PitchBox } from "../components/PitchBox";
 import {PressBox} from "../components/PressBox";
@@ -19,35 +19,37 @@ const QUOTE_TEXT = 'dOrg helped me save 15% on car insurance.';
 const QUOTE_CITATION = 'Satoshi - Bitcoin, Inc.';
 const CLOSE_BUTTON_TEXT = 'GET IN TOUCH';
 
-const Root = styled(Box)({
-  margins: 'auto'
+const Root = styled(Grid)({
+  margins: 'auto',
+  width: '100vw'
 });
 
-const Container = styled(Grid)({
-  width: '85rem'
+const ContentContainer = styled(Grid)({
+  maxWidth: '85vw'
 });
 
 const StatsContainer = styled(Grid)({
-  width: '42.5rem'
+  width: '100%'
 });
 
 const PitchesContainer = styled(Grid)({
-  width: '85rem'
+  width: '100%'
 });
 
 export const About: React.FC = () => {
 
   const history = useHistory();
-  const navigateToContactPage = () => { history.push(routes.contact.path) };
+  const navigateToContactPage = () => history.push(routes.contact.path);
 
   return (
-    <Root>
-      <Container container spacing={0} justify="center" alignItems='flex-start'>
-        <Grid item xs={6}>
+    <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
+      <Grid item xs={1} style={{height: '100%', maxWidth: '7.5vw'}} />
+      <ContentContainer container item xs={10} spacing={0} direction='row' justify="center" alignItems='flex-start'>
+        <Grid item xs={12} lg={6}>
           <AboutTitleBox text={ABOUT_TITLE} />
           <PressBox press={press} />
         </Grid>
-        <StatsContainer container item xs={6} spacing={0} justify="center">
+        <StatsContainer container item xs={12} lg={6} spacing={0} justify="center">
           {Object.values(stats).map((stat: Stat, index: number) => (
             <Grid item xs={6} key={`stat-${index}`}>
               <StatBox stat={stat} />
@@ -57,15 +59,18 @@ export const About: React.FC = () => {
         <Grid item xs={12}>
           <PitchTitleBox text={PITCHES_TITLE} />
         </Grid>
-        <PitchesContainer container item spacing={0} justify="center">
+        <PitchesContainer container item xs={12} spacing={0} justify="center">
           {Object.values(pitches).map((pitch: Pitch, index: number) => (
-            <Grid item xs={6} key={`pitch-${index}`}>
+            <Grid item xs={12} lg={6} key={`pitch-${index}`}>
               <PitchBox pitch={pitch} />
             </Grid>
           ))}
         </PitchesContainer>
-        <CloseBox quote={QUOTE_TEXT} citation={QUOTE_CITATION} buttonText={CLOSE_BUTTON_TEXT} onButtonClick={navigateToContactPage} />
-      </Container>
+        <Grid item xs={12}>
+          <CloseBox quote={QUOTE_TEXT} citation={QUOTE_CITATION} buttonText={CLOSE_BUTTON_TEXT} onButtonClick={navigateToContactPage} />
+        </Grid>
+      </ContentContainer>
+      <Grid item xs={1} style={{height: '100%', maxWidth: '7.5vw'}} />
     </Root>
   );
 }

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -10,6 +10,8 @@ import {press} from "../constants/press";
 import {AboutTitleBox} from "../components/AboutTitleBox";
 import {PitchTitleBox} from "../components/PitchTitleBox";
 import {CloseBox} from "../components/CloseBox";
+import {LeftMargin} from "../components/LeftMargin";
+import { RightMargin } from "../components/RightMargin"
 import {routes} from "../constants/routes";
 
 
@@ -36,21 +38,22 @@ const PitchesContainer = styled(Grid)({
   width: '100%'
 });
 
+const borderStyle = '1px solid rgba(255, 255, 255, 0.25)';
 const useBorders = makeStyles({
   allBorders: {
-    border: '1px solid rgba(255, 255, 255, 0.25)'
+    border: borderStyle
   },
   rightBorder: {
-    borderRight: '1px solid rgba(255, 255, 255, 0.25)'
+    borderRight: borderStyle
   },
   leftBorder: {
-    borderLeft: '1px solid rgba(255, 255, 255, 0.25)'
+    borderLeft: borderStyle
   },
   topBorder: {
-    borderTop: '1px solid rgba(255, 255, 255, 0.25)'
+    borderTop: borderStyle
   },
   bottomBorder: {
-    borderBottom: '1px solid rgba(255, 255, 255, 0.25)'
+    borderBottom: borderStyle
   }
 });
 
@@ -63,7 +66,7 @@ export const About: React.FC = () => {
 
   return (
     <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
-      <Grid item xs={1} style={{height: '100%', maxWidth: '7.5vw'}} />
+      <LeftMargin xs={1} border={borders.allBorders} centerLine={borderStyle}/>
       <ContentContainer container item xs={10} spacing={0} direction='row' justify="center" alignItems='flex-start'>
         <Grid item xs={12} lg={6}>
           <AboutTitleBox text={ABOUT_TITLE} classes={borders.allBorders} />
@@ -90,7 +93,7 @@ export const About: React.FC = () => {
           <CloseBox quote={QUOTE_TEXT} citation={QUOTE_CITATION} buttonText={CLOSE_BUTTON_TEXT} onButtonClick={navigateToContactPage} classes={borders.allBorders} />
         </Grid>
       </ContentContainer>
-      <Grid item xs={1} style={{height: '100%', maxWidth: '7.5vw'}} />
+      <RightMargin xs={1} border={borders.allBorders} centerLine={borderStyle} />
     </Root>
   );
 }

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useHistory } from 'react-router-dom'
-import { Grid, styled } from "@material-ui/core";
+import { Grid, makeStyles, styled} from "@material-ui/core";
 import { StatBox } from "../components/StatBox";
 import { PitchBox } from "../components/PitchBox";
 import {PressBox} from "../components/PressBox";
@@ -36,38 +36,58 @@ const PitchesContainer = styled(Grid)({
   width: '100%'
 });
 
+const useBorders = makeStyles({
+  allBorders: {
+    border: '1px solid rgba(255, 255, 255, 0.25)'
+  },
+  rightBorder: {
+    borderRight: '1px solid rgba(255, 255, 255, 0.25)'
+  },
+  leftBorder: {
+    borderLeft: '1px solid rgba(255, 255, 255, 0.25)'
+  },
+  topBorder: {
+    borderTop: '1px solid rgba(255, 255, 255, 0.25)'
+  },
+  bottomBorder: {
+    borderBottom: '1px solid rgba(255, 255, 255, 0.25)'
+  }
+});
+
 export const About: React.FC = () => {
 
   const history = useHistory();
   const navigateToContactPage = () => history.push(routes.contact.path);
+
+  const borders = useBorders();
 
   return (
     <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
       <Grid item xs={1} style={{height: '100%', maxWidth: '7.5vw'}} />
       <ContentContainer container item xs={10} spacing={0} direction='row' justify="center" alignItems='flex-start'>
         <Grid item xs={12} lg={6}>
-          <AboutTitleBox text={ABOUT_TITLE} />
-          <PressBox press={press} />
+          <AboutTitleBox text={ABOUT_TITLE} classes={borders.allBorders} />
+          <PressBox press={press} classes={borders.allBorders} />
         </Grid>
         <StatsContainer container item xs={12} lg={6} spacing={0} justify="center">
           {Object.values(stats).map((stat: Stat, index: number) => (
             <Grid item xs={6} key={`stat-${index}`}>
-              <StatBox stat={stat} />
+              <StatBox stat={stat} classes={borders.allBorders} />
             </Grid>
           ))}
         </StatsContainer>
         <Grid item xs={12}>
-          <PitchTitleBox text={PITCHES_TITLE} />
+          <PitchTitleBox text={PITCHES_TITLE} classes={borders.allBorders} />
         </Grid>
         <PitchesContainer container item xs={12} spacing={0} justify="center">
           {Object.values(pitches).map((pitch: Pitch, index: number) => (
             <Grid item xs={12} lg={6} key={`pitch-${index}`}>
-              <PitchBox pitch={pitch} />
+              <PitchBox pitch={pitch} classes={borders.allBorders} />
             </Grid>
           ))}
         </PitchesContainer>
         <Grid item xs={12}>
-          <CloseBox quote={QUOTE_TEXT} citation={QUOTE_CITATION} buttonText={CLOSE_BUTTON_TEXT} onButtonClick={navigateToContactPage} />
+          <CloseBox quote={QUOTE_TEXT} citation={QUOTE_CITATION} buttonText={CLOSE_BUTTON_TEXT} onButtonClick={navigateToContactPage} classes={borders.allBorders} />
         </Grid>
       </ContentContainer>
       <Grid item xs={1} style={{height: '100%', maxWidth: '7.5vw'}} />

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -107,5 +107,14 @@ export const theme = createMuiTheme({
         }
       }
     }
-  }
+  },
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 600,
+      md: 960,
+      lg: 1280,
+      xl: 1485,
+    },
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,7 +1603,6 @@ __metadata:
     react-dom: ^17.0.1
     react-ga: ^3.3.0
     react-refresh: ^0.9.0
-    react-responsive: ^8.2.0
     react-router-dom: ^5.2.0
     react-scripts: 4.0.1
     serve: ^11.3.2
@@ -5685,13 +5684,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-mediaquery@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "css-mediaquery@npm:0.1.2"
-  checksum: 571ab2efdba0dead1315eb82b1e53917b4aeb45f07cc2ff97bfe3c6443cd036843d944044661561b5585d1f64ecbcad112052b40846ae4d85ef7d5e978e996e4
-  languageName: node
-  linkType: hard
-
 "css-prefers-color-scheme@npm:^3.1.1":
   version: 3.1.1
   resolution: "css-prefers-color-scheme@npm:3.1.1"
@@ -8736,7 +8728,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"hyphenate-style-name@npm:^1.0.0, hyphenate-style-name@npm:^1.0.3":
+"hyphenate-style-name@npm:^1.0.3":
   version: 1.0.4
   resolution: "hyphenate-style-name@npm:1.0.4"
   checksum: 4cfeb47e98eab9c25e6dece20da772cc914a9f8e5ee794cf8db105b0649dd64a61d8ee8ff32acf23ae0ac181db8fcbe4a6abb2f7de48ae52b42a85bbf1aacb86
@@ -11106,15 +11098,6 @@ fsevents@~2.1.2:
   dependencies:
     lodash: ^4.17.4
   checksum: 89328f15d3629b447a947b703ceb214aa403bb52ec124f0f9f55fab5feec392fe827507ec86d91a14ff2e75abdaeb8ea74627f6487b124a03ef36d553f452587
-  languageName: node
-  linkType: hard
-
-"matchmediaquery@npm:^0.3.0":
-  version: 0.3.1
-  resolution: "matchmediaquery@npm:0.3.1"
-  dependencies:
-    css-mediaquery: ^0.1.2
-  checksum: face426fe3fd743d08d70c2e92c103c14419268f7ba0069bacd04c91e819a7ca270d195e2e6793169a6fcacc22b225965d685ec3fc144babee84f46659645757
   languageName: node
   linkType: hard
 
@@ -13753,7 +13736,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
+"prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
   version: 15.7.2
   resolution: "prop-types@npm:15.7.2"
   dependencies:
@@ -14245,20 +14228,6 @@ fsevents@~2.1.2:
   version: 0.9.0
   resolution: "react-refresh@npm:0.9.0"
   checksum: 300dc431389f4c532bdfec08d5bc59b591c8c440486a7d5770c8954adf3afe62501b659c5acbdb7831751e8be506eb90a6f72491fab40352f3b3fba16897acf6
-  languageName: node
-  linkType: hard
-
-"react-responsive@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "react-responsive@npm:8.2.0"
-  dependencies:
-    hyphenate-style-name: ^1.0.0
-    matchmediaquery: ^0.3.0
-    prop-types: ^15.6.1
-    shallow-equal: ^1.1.0
-  peerDependencies:
-    react: ">=16.8.0"
-  checksum: 3209a32c74d6749e306b7fd521e2156c04d21e40af2d9a4493d22f22d13deb64d6ca1439526a56342779a1a8819be7354ff111d877a3cf3964ee50e9a84e77d9
   languageName: node
   linkType: hard
 
@@ -15492,13 +15461,6 @@ resolve@1.18.1:
   dependencies:
     kind-of: ^6.0.2
   checksum: e329e054c286f0681fd8a9e5c353999519332f12510a99e189ea9cfa0337adb6f1414639d44493418ef6790a693b78c354525269f5db25a9feddd8b4d7891a62
-  languageName: node
-  linkType: hard
-
-"shallow-equal@npm:^1.1.0":
-  version: 1.2.1
-  resolution: "shallow-equal@npm:1.2.1"
-  checksum: 5002ac4a3639e35782d3cb21073d48e1e4f85321cc54608f48b2331f6db6d54e4f4b44ed81ec4d75385ebe893e8286752b1e29595381e6adad72dd836f001b7f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,6 +1603,7 @@ __metadata:
     react-dom: ^17.0.1
     react-ga: ^3.3.0
     react-refresh: ^0.9.0
+    react-responsive: ^8.2.0
     react-router-dom: ^5.2.0
     react-scripts: 4.0.1
     serve: ^11.3.2
@@ -5684,6 +5685,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-mediaquery@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "css-mediaquery@npm:0.1.2"
+  checksum: 571ab2efdba0dead1315eb82b1e53917b4aeb45f07cc2ff97bfe3c6443cd036843d944044661561b5585d1f64ecbcad112052b40846ae4d85ef7d5e978e996e4
+  languageName: node
+  linkType: hard
+
 "css-prefers-color-scheme@npm:^3.1.1":
   version: 3.1.1
   resolution: "css-prefers-color-scheme@npm:3.1.1"
@@ -8728,7 +8736,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"hyphenate-style-name@npm:^1.0.3":
+"hyphenate-style-name@npm:^1.0.0, hyphenate-style-name@npm:^1.0.3":
   version: 1.0.4
   resolution: "hyphenate-style-name@npm:1.0.4"
   checksum: 4cfeb47e98eab9c25e6dece20da772cc914a9f8e5ee794cf8db105b0649dd64a61d8ee8ff32acf23ae0ac181db8fcbe4a6abb2f7de48ae52b42a85bbf1aacb86
@@ -11098,6 +11106,15 @@ fsevents@~2.1.2:
   dependencies:
     lodash: ^4.17.4
   checksum: 89328f15d3629b447a947b703ceb214aa403bb52ec124f0f9f55fab5feec392fe827507ec86d91a14ff2e75abdaeb8ea74627f6487b124a03ef36d553f452587
+  languageName: node
+  linkType: hard
+
+"matchmediaquery@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "matchmediaquery@npm:0.3.1"
+  dependencies:
+    css-mediaquery: ^0.1.2
+  checksum: face426fe3fd743d08d70c2e92c103c14419268f7ba0069bacd04c91e819a7ca270d195e2e6793169a6fcacc22b225965d685ec3fc144babee84f46659645757
   languageName: node
   linkType: hard
 
@@ -13736,7 +13753,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
+"prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
   version: 15.7.2
   resolution: "prop-types@npm:15.7.2"
   dependencies:
@@ -14228,6 +14245,20 @@ fsevents@~2.1.2:
   version: 0.9.0
   resolution: "react-refresh@npm:0.9.0"
   checksum: 300dc431389f4c532bdfec08d5bc59b591c8c440486a7d5770c8954adf3afe62501b659c5acbdb7831751e8be506eb90a6f72491fab40352f3b3fba16897acf6
+  languageName: node
+  linkType: hard
+
+"react-responsive@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "react-responsive@npm:8.2.0"
+  dependencies:
+    hyphenate-style-name: ^1.0.0
+    matchmediaquery: ^0.3.0
+    prop-types: ^15.6.1
+    shallow-equal: ^1.1.0
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 3209a32c74d6749e306b7fd521e2156c04d21e40af2d9a4493d22f22d13deb64d6ca1439526a56342779a1a8819be7354ff111d877a3cf3964ee50e9a84e77d9
   languageName: node
   linkType: hard
 
@@ -15461,6 +15492,13 @@ resolve@1.18.1:
   dependencies:
     kind-of: ^6.0.2
   checksum: e329e054c286f0681fd8a9e5c353999519332f12510a99e189ea9cfa0337adb6f1414639d44493418ef6790a693b78c354525269f5db25a9feddd8b4d7891a62
+  languageName: node
+  linkType: hard
+
+"shallow-equal@npm:^1.1.0":
+  version: 1.2.1
+  resolution: "shallow-equal@npm:1.2.1"
+  checksum: 5002ac4a3639e35782d3cb21073d48e1e4f85321cc54608f48b2331f6db6d54e4f4b44ed81ec4d75385ebe893e8286752b1e29595381e6adad72dd836f001b7f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
First draft of desktop about page. Responsively approaches mobile about page, but some additional polish and mobile-specific adjustments are required for small screens. Closes #18.