### PR TITLE
Desktop Responsiveness Update

### DIFF
--- a/src/components/AboutTitleBox.tsx
+++ b/src/components/AboutTitleBox.tsx
@@ -6,17 +6,17 @@ import { theme } from "../theme";
 const StyledBox = styled(Box)({
   margin: 'auto',
   width: '100%',
-  height: '38.25rem',
+  height: '38.25vw',
   background: 'transparent',
   boxSizing: 'border-box',
   position: 'relative'
 });
 
 const StyledText = styled(Typography)({
-  maxWidth: '36rem',
-  padding: '4.3rem 1.75rem',
+  maxWidth: '36vw',
+  padding: '4.3vw 1.75vw',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '3.25rem',
+  fontSize: '3.25vw',
   fontWeight: 600,
   fontStretch: "normal",
   fontStyle: "normal",

--- a/src/components/CloseBox.tsx
+++ b/src/components/CloseBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Box, styled, Typography, Grid, useMediaQuery, useTheme, Theme} from '@material-ui/core'
+import {Box, styled, Typography, Grid} from '@material-ui/core'
 import { theme } from "../theme";
 import { CloseButton } from "./CloseButton";
 
@@ -7,17 +7,17 @@ import { CloseButton } from "./CloseButton";
 const StyledBox = styled(Box)({
   margin: 'auto',
   width: '100%',
-  height: '14.6rem',
+  height: '14.6vw',
   background: theme.palette.secondary.main,
   boxSizing: 'border-box',
   position: 'relative'
 });
 
 const StyledQuote = styled(Typography)({
-  maxWidth: '31rem',
-  height: '6.375rem',
+  maxWidth: '31vw',
+  height: '6.375vw',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '2.25rem',
+  fontSize: '2.25vw',
   fontWeight: 300,
   fontStretch: "normal",
   fontStyle: "normal",
@@ -29,10 +29,10 @@ const StyledQuote = styled(Typography)({
 
 const StyledCitation = styled(Typography)({
   width: '100%',
-  height: '1.25rem',
-  margin: '2rem 0 0 0',
+  height: '1.25vw',
+  margin: '2vw 0 0 0',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '1.125rem',
+  fontSize: '1.125vw',
   fontWeight: 500,
   fontStretch: "normal",
   fontStyle: "normal",
@@ -43,17 +43,17 @@ const StyledCitation = styled(Typography)({
 });
 
 const StyledIcon = styled('img')({
-  width: '5.6rem',
-  height: '3.9rem',
-  margin: '1rem',
+  width: '5.6vw',
+  height: '3.9vw',
+  margin: '1vw',
   objectFit: "contain",
   position: 'relative',
-  bottom: '1.6rem'
+  bottom: '1.6vw'
 });
 
 const StyledRings = styled('img')({
-  width: '13.5rem',
-  height: '13.7rem',
+  width: '13.5vw',
+  height: '13.7vw',
   objectFit: 'contain',
   transform: 'scaleX(-1)',
   position: 'absolute',
@@ -71,14 +71,10 @@ interface Props {
 
 export const CloseBox: React.FC<Props> = (props: Props) => {
 
-  const theme: Theme = useTheme();
-  const extraLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
-
   return (
     <StyledBox className={props.classes}>
       <Grid container spacing={0} direction='row' justify='flex-start' alignItems='flex-start' style={{height: 'inherit'}}>
-        {extraLargeScreen &&
-        (<Grid container item xs={8} lg={7} xl={6} spacing={0} direction='row' justify='space-evenly' alignItems='center' style={{height: 'inherit'}}>
+        <Grid container item xs={8} lg={7} xl={6} spacing={0} direction='row' justify='space-evenly' alignItems='center' style={{height: 'inherit'}}>
           <Grid item>
             <StyledIcon src='imgs/quotation-mark-icon.svg' alt={'quotation mark icon'} />
           </Grid>
@@ -86,14 +82,7 @@ export const CloseBox: React.FC<Props> = (props: Props) => {
             <StyledQuote><strong>“</strong>{props.quote}<strong>”</strong></StyledQuote>
             <StyledCitation>{props.citation}</StyledCitation>
           </Grid>
-        </Grid>)}
-        {!extraLargeScreen &&
-        (<Grid container item xs={8} lg={7} xl={6} spacing={0} direction='row' justify='space-evenly' alignItems='center' style={{height: 'inherit'}}>
-          <Grid item>
-            <StyledQuote><strong>“</strong>{props.quote}<strong>”</strong></StyledQuote>
-            <StyledCitation>{props.citation}</StyledCitation>
-          </Grid>
-        </Grid>)}
+        </Grid>
         <Grid item xs={4} lg={5} xl={6} container direction='row' justify='center' alignItems='center' style={{height: 'inherit'}}>
           <Grid item>
             <CloseButton text={props.buttonText} handleClick={props.onButtonClick} />

--- a/src/components/CloseBoxMobile.tsx
+++ b/src/components/CloseBoxMobile.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {Box, styled, Typography, Grid} from '@material-ui/core'
 import { theme } from "../theme";
-import { CloseButton } from "./CloseButton";
+import {CloseButtonMobile} from "./CloseButtonMobile";
 
 
 const StyledBox = styled(Box)({
@@ -70,7 +70,7 @@ export const CloseBoxMobile: React.FC<Props> = (props: Props) => {
           <StyledCitation>{props.citation}</StyledCitation>
         </Grid>
         <Grid item>
-          <CloseButton text={props.buttonText} handleClick={props.onButtonClick} />
+          <CloseButtonMobile text={props.buttonText} handleClick={props.onButtonClick} />
         </Grid>
       </Grid>
       <StyledRings src='imgs/concentric-rings-right.svg' alt={'concentric rings flourish'} />

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -6,11 +6,11 @@ import { theme } from "../theme";
 const StyleGrid = styled(Grid)({
   margin: 'auto',
   width: '100%',
-  height: '4.5rem',
-  padding: '1.5rem 1.5rem 1.5rem 2.5rem',
+  height: '4.5vw',
+  padding: '1.5vw 1.5vw 1.5vw 2.5vw',
   background: 'transparent',
   boxSizing: 'border-box',
-  boxShadow: '0 0.1875rem 0.375rem 0 rgba(0, 0, 0, 0.16), inset 0 0.1875rem 0.375rem 0 rgba(0, 0, 0, 0.16)',
+  boxShadow: '0 0.1875vw 0.375vw 0 rgba(0, 0, 0, 0.16), inset 0 0.1875vw 0.375vw 0 rgba(0, 0, 0, 0.16)',
   borderRadius: 0,
   border: 'solid 2px ' + theme.palette.text.primary,
   '&:hover': {
@@ -21,11 +21,11 @@ const StyleGrid = styled(Grid)({
 
 const StyleText = styled(Typography)({
   width: '100%',
-  height: '1rem',
+  height: '1vw',
   margin: 'auto',
   padding: 0,
   fontFamily: theme.typography.fontFamily,
-  fontSize: '0.938rem',
+  fontSize: '0.938vw',
   fontWeight: 'bold',
   fontStretch: "normal",
   fontStyle: "normal",
@@ -36,9 +36,9 @@ const StyleText = styled(Typography)({
 });
 
 const StyleArrow = styled('img')({
-  width: '1.5rem',
-  height: '1.5rem',
-  margin: '0 0 0 1.75rem',
+  width: '1.5vw',
+  height: '1.5vw',
+  margin: '0 0 0 1.75vw',
   padding: 0,
   objectFit: "contain"
 });

--- a/src/components/CloseButtonMobile.tsx
+++ b/src/components/CloseButtonMobile.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import {styled, Typography, Grid, ButtonBase} from '@material-ui/core'
+import { theme } from "../theme";
+
+
+const StyleGrid = styled(Grid)({
+  margin: 'auto',
+  width: '100%',
+  height: '4.5rem',
+  padding: '1.5rem 1.5rem 1.5rem 2.5rem',
+  background: 'transparent',
+  boxSizing: 'border-box',
+  boxShadow: '0 0.1875rem 0.375rem 0 rgba(0, 0, 0, 0.16), inset 0 0.1875rem 0.375rem 0 rgba(0, 0, 0, 0.16)',
+  borderRadius: 0,
+  border: 'solid 2px ' + theme.palette.text.primary,
+  '&:hover': {
+    border: 'solid 1px ' + theme.palette.text.primary,
+  },
+  zIndex: 1
+});
+
+const StyleText = styled(Typography)({
+  width: '100%',
+  height: '1rem',
+  margin: 'auto',
+  padding: 0,
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '0.938rem',
+  fontWeight: 'bold',
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1,
+  letterSpacing: '1.5px',
+  textAlign: "center",
+  color: theme.palette.text.primary
+});
+
+const StyleArrow = styled('img')({
+  width: '1.5rem',
+  height: '1.5rem',
+  margin: '0 0 0 1.75rem',
+  padding: 0,
+  objectFit: "contain"
+});
+
+interface Props {
+  text: string;
+  handleClick: () => void
+}
+
+export const CloseButtonMobile: React.FC<Props> = (props: Props) => {
+
+  return (
+    <ButtonBase onClick={() => props.handleClick()}>
+      <StyleGrid container spacing={0} justify={'space-between'} alignItems={'center'}>
+        <Grid item>
+          <StyleText>{props.text}</StyleText>
+        </Grid>
+        <Grid item>
+          <StyleArrow src='imgs/right-arrow.svg' alt={'right-pointing arrow'} />
+        </Grid>
+      </StyleGrid>
+    </ButtonBase>
+  );
+}

--- a/src/components/LeftMargin.tsx
+++ b/src/components/LeftMargin.tsx
@@ -18,12 +18,11 @@ interface Props {
 export const LeftMargin: React.FC<Props> = (props: Props) => {
 
   const theme: Theme = useTheme();
-  const largeScreen = useMediaQuery(theme.breakpoints.up('lg'));
   const desktop = useMediaQuery(theme.breakpoints.up('md'));
 
   return (
-    <StyledGrid item xs={props.xs} style={{height: largeScreen ? '116.775rem' : (desktop ? '202.75rem' : '144.25rem')}}>
-      <CenterLine item style={{borderBottom: props.border, height: desktop ? '57.375rem' : '47.375rem'}} />
+    <StyledGrid item xs={props.xs} style={{height: desktop ? '116.775vw' : '144.25rem'}}>
+      <CenterLine item style={{borderBottom: props.border, height: desktop ? '57.375vw' : '47.375rem'}} />
     </StyledGrid>
   );
 }

--- a/src/components/LeftMargin.tsx
+++ b/src/components/LeftMargin.tsx
@@ -18,7 +18,7 @@ interface Props {
 export const LeftMargin: React.FC<Props> = (props: Props) => {
 
   const theme: Theme = useTheme();
-  const desktop = useMediaQuery(theme.breakpoints.up('md'));
+  const desktop = useMediaQuery(theme.breakpoints.up('lg'));
 
   return (
     <StyledGrid item xs={props.xs} style={{height: desktop ? '116.775vw' : '144.25rem'}}>

--- a/src/components/PitchBox.tsx
+++ b/src/components/PitchBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {styled, Typography, Grid, useMediaQuery, useTheme, Theme} from '@material-ui/core'
+import {styled, Typography, Grid} from '@material-ui/core'
 import { theme } from "../theme";
 import {Pitch} from "../constants/pitches";
 import {hexToRGB} from "../utils";
@@ -63,32 +63,15 @@ interface Props {
 
 export const PitchBox: React.FC<Props> = (props: Props) => {
 
-  const theme: Theme = useTheme();
-  const extraLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
-
-  if (extraLargeScreen) {
-    return (
-      <StyledGrid className={props.classes} container direction='row' spacing={0} justify='flex-start' alignItems='center'>
-        <Grid item xs={12} sm={2}>
-          <StyledIcon src={props.pitch.icon} alt='icon' />
-        </Grid>
-        <Grid item xs={12} sm={10}>
-          <StyledPitch>{props.pitch.pitch}</StyledPitch>
-          <StyledDetail>{props.pitch.detail}</StyledDetail>
-        </Grid>
-      </StyledGrid>
-    );
-  } else {
-    return (
-      <StyledGrid className={props.classes} container direction='row' spacing={0} justify='flex-start' alignItems='center' style={{padding: '4% 3.375%'}}>
-        <Grid item xs={12} sm={2}>
-          <StyledIcon src={props.pitch.icon} alt='icon' style={{margin: 0, marginBottom: '1vw'}} />
-        </Grid>
-        <Grid item xs={12} sm={10}>
-          <StyledPitch>{props.pitch.pitch}</StyledPitch>
-          <StyledDetail>{props.pitch.detail}</StyledDetail>
-        </Grid>
-      </StyledGrid>
-    );
-  }
+  return (
+    <StyledGrid className={props.classes} container direction='row' spacing={0} justify='flex-start' alignItems='center'>
+      <Grid item xs={12} sm={2}>
+        <StyledIcon src={props.pitch.icon} alt='icon' />
+      </Grid>
+      <Grid item xs={12} sm={10}>
+        <StyledPitch>{props.pitch.pitch}</StyledPitch>
+        <StyledDetail>{props.pitch.detail}</StyledDetail>
+      </Grid>
+    </StyledGrid>
+  );
 }

--- a/src/components/PitchBox.tsx
+++ b/src/components/PitchBox.tsx
@@ -7,7 +7,7 @@ import {hexToRGB} from "../utils";
 const StyledGrid = styled(Grid)({
   margin: 'auto',
   width: '100%',
-  height: '14.3rem',
+  height: '14.3vw',
   padding: '9% 6.75%',
   backgroundColor: 'rgba(0, 0, 0, 0.15)',
   boxSizing: 'border-box',
@@ -19,11 +19,11 @@ const StyledGrid = styled(Grid)({
 });
 
 const StyledDetail = styled(Typography)({
-  width: '24rem',
-  height: '2.8rem',
-  margin: '1.25rem 0 0 0',
+  width: '24vw',
+  height: '2.8vw',
+  margin: '1.25vw 0 0 0',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '0.938rem',
+  fontSize: '0.938vw',
   fontWeight: 500,
   fontStretch: 'normal',
   fontStyle: 'normal',
@@ -37,7 +37,7 @@ const StyledPitch = styled(Typography)({
   width: '100%',
   height: '100%',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '2rem',
+  fontSize: '2vw',
   fontWeight: 600,
   fontStretch: "normal",
   fontStyle: "normal",
@@ -48,10 +48,10 @@ const StyledPitch = styled(Typography)({
 });
 
 const StyledIcon = styled('img')({
-  width: "3.75rem",
-  height: "3.75rem",
-  marginRight: '2.3rem',
-  marginBottom: '3rem',
+  width: "3.75vw",
+  height: "3.75vw",
+  marginRight: '2.3vw',
+  marginBottom: '3vw',
   objectFit: "contain",
   float: 'left'
 });
@@ -82,7 +82,7 @@ export const PitchBox: React.FC<Props> = (props: Props) => {
     return (
       <StyledGrid className={props.classes} container direction='row' spacing={0} justify='flex-start' alignItems='center' style={{padding: '4% 3.375%'}}>
         <Grid item xs={12} sm={2}>
-          <StyledIcon src={props.pitch.icon} alt='icon' style={{margin: 0, marginBottom: '1rem'}} />
+          <StyledIcon src={props.pitch.icon} alt='icon' style={{margin: 0, marginBottom: '1vw'}} />
         </Grid>
         <Grid item xs={12} sm={10}>
           <StyledPitch>{props.pitch.pitch}</StyledPitch>

--- a/src/components/PitchBox.tsx
+++ b/src/components/PitchBox.tsx
@@ -64,7 +64,7 @@ interface Props {
 export const PitchBox: React.FC<Props> = (props: Props) => {
 
   const theme: Theme = useTheme();
-  const extraLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+  const extraLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
 
   if (extraLargeScreen) {
     return (

--- a/src/components/PitchTitleBox.tsx
+++ b/src/components/PitchTitleBox.tsx
@@ -6,16 +6,16 @@ import { theme } from "../theme";
 const StyledGrid = styled(Grid)({
   margin: 'auto',
   width: '100%',
-  height: '16.2rem',
+  height: '16.2vw',
   background: 'transparent',
   boxSizing: 'border-box',
   position: 'relative'
 });
 
 const StyledText = styled(Typography)({
-  marginLeft: '1.8rem',
+  marginLeft: '1.8vw',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '3.25rem',
+  fontSize: '3.25vw',
   fontWeight: 600,
   fontStretch: "normal",
   fontStyle: "normal",
@@ -26,8 +26,8 @@ const StyledText = styled(Typography)({
 });
 
 const StyledRings = styled('img')({
-  width: '19.125rem',
-  height: '19.063rem',
+  width: '19.125vw',
+  height: '19.063vw',
   objectFit: 'contain',
   position: 'absolute',
   top: 0,
@@ -36,7 +36,7 @@ const StyledRings = styled('img')({
 });
 
 const Accent = styled('div')({
-  height: '5rem',
+  height: '5vw',
   position: 'absolute',
   top: 0,
   left: '50%',

--- a/src/components/PressBox.tsx
+++ b/src/components/PressBox.tsx
@@ -7,8 +7,8 @@ import {Article, Press} from "../constants/press";
 const StyledBox = styled(Box)({
   margin: 'auto',
   width: '100%',
-  height: '19.125rem',
-  padding: '4.7% 0',
+  height: '19.125vw',
+  padding: '1vw 0',
   backgroundColor: theme.palette.secondary.main,
   boxSizing: 'border-box',
   position: 'relative'
@@ -20,8 +20,8 @@ const StyledGrid = styled(Grid)({
 });
 
 const StyledIcon = styled('img')({
-  width: "12.5rem",
-  height: "3rem",
+  width: "12.5vw",
+  height: "3vw",
   margin: 'auto',
   objectFit: "contain",
   background: 'transparent',
@@ -31,8 +31,8 @@ const StyledIcon = styled('img')({
 });
 
 const StyledRings = styled('img')({
-  width: '14.313rem',
-  height: '14.5rem',
+  width: '14.313vw',
+  height: '14.5vw',
   objectFit: 'contain',
   position: 'absolute',
   top: 0,

--- a/src/components/RightMargin.tsx
+++ b/src/components/RightMargin.tsx
@@ -46,7 +46,7 @@ const Accents: React.FC<Props> = (props: Props) => {
 export const RightMargin: React.FC<Props> = (props: Props) => {
 
   const theme: Theme = useTheme();
-  const desktop = useMediaQuery(theme.breakpoints.up('md'));
+  const desktop = useMediaQuery(theme.breakpoints.up('lg'));
 
   return (
     <StyledGrid item xs={props.xs} style={{borderLeft: props.border, height: desktop ? '116.775vw' : '144.25rem'}}>

--- a/src/components/RightMargin.tsx
+++ b/src/components/RightMargin.tsx
@@ -8,21 +8,21 @@ const StyledGrid = styled(Grid)({
 
 const CenterLine = styled(Grid)({
   width: 'inherit',
-  height: '57.375rem',
+  height: '57.375vw',
 });
 
 const RectangleAccentPrimary = styled('div')({
-  width: '1.625rem',
-  height: '0.125rem',
-  marginTop: '1.125rem',
+  width: '1.625vw',
+  height: '0.125vw',
+  marginTop: '1.125vw',
   opacity: '0.6',
   backgroundColor: theme.palette.text.primary
 });
 
 const RectangleAccentSecondary = styled('div')({
-  width: '2.875rem',
-  height: '0.125rem',
-  marginTop: '1.125rem',
+  width: '2.875vw',
+  height: '0.125vw',
+  marginTop: '1.125vw',
   backgroundColor: theme.palette.text.secondary
 });
 
@@ -46,14 +46,13 @@ const Accents: React.FC<Props> = (props: Props) => {
 export const RightMargin: React.FC<Props> = (props: Props) => {
 
   const theme: Theme = useTheme();
-  const largeScreen = useMediaQuery(theme.breakpoints.up('lg'));
   const desktop = useMediaQuery(theme.breakpoints.up('md'));
 
   return (
-    <StyledGrid item xs={props.xs} style={{borderLeft: props.border, height: largeScreen ? '116.775rem' : (desktop ? '202.75rem' : '144.25rem')}}>
-      {largeScreen ?
+    <StyledGrid item xs={props.xs} style={{borderLeft: props.border, height: desktop ? '116.775vw' : '144.25rem'}}>
+      {desktop ?
         <Accents xs={props.xs} border={props.border}/> :
-        <CenterLine item style={{borderBottom: props.border, height: desktop ? '57.375rem' : '47.375rem'}} />}
+        <CenterLine item style={{borderBottom: props.border, height: '47.375rem'}} />}
     </StyledGrid>
   );
 }

--- a/src/components/StatBox.tsx
+++ b/src/components/StatBox.tsx
@@ -7,8 +7,8 @@ import { theme } from "../theme";
 const StyledBox = styled(Box)({
   margin: 'auto',
   width: '100%',
-  height: '19.125rem',
-  padding: '1.75rem',
+  height: '19.125vw',
+  padding: '1.75vw',
   backgroundColor: 'transparent',
   boxSizing: 'border-box',
   '&:hover': {
@@ -20,7 +20,7 @@ const StyledTitle = styled(Typography)({
   width: '100%',
   height: '100%',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '0.938rem',
+  fontSize: '0.938vw',
   fontWeight: 'bold',
   fontStretch: 'normal',
   fontStyle: 'normal',
@@ -33,9 +33,9 @@ const StyledTitle = styled(Typography)({
 const StyledStat = styled(Typography)({
   width: "100%",
   height: "100%",
-  margin: '0 0 1.938rem 0',
+  margin: '0 0 1.938vw 0',
   fontFamily: theme.typography.fontFamily,
-  fontSize: "3.25rem",
+  fontSize: "3.25vw",
   fontWeight: "bold",
   fontStretch: "normal",
   fontStyle: "normal",
@@ -46,9 +46,9 @@ const StyledStat = styled(Typography)({
 });
 
 const StyledIcon = styled('img')({
-  width: "1.5rem",
-  height: "1.5rem",
-  margin: '0 0 3.5rem 0',
+  width: "1.5vw",
+  height: "1.5vw",
+  margin: '0 0 3.5vw 0',
   objectFit: "contain",
   float: 'right'
 });

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -62,11 +62,11 @@ export const About: React.FC = () => {
       <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
         <LeftMargin xs={1} border={borderStyle} />
         <ContentContainer container item xs={10} spacing={0} direction='row' justify="center" alignItems='flex-start'>
-          <Grid item xs={12} lg={6}>
+          <Grid item xs={6}>
             <AboutTitleBox text={ABOUT_TITLE} classes={borders.bottomLeftBorder} />
             <PressBox press={press} classes={borders.bottomLeftBorder} />
           </Grid>
-          <StatsContainer container item xs={12} lg={6} spacing={0} justify="center">
+          <StatsContainer container item xs={6} spacing={0} justify="center">
             {Object.values(stats).map((stat: Stat, index: number) => (
               <Grid item xs={6} key={`stat-${index}`}>
                 <StatBox stat={stat} classes={borders.bottomLeftBorder} />
@@ -78,7 +78,7 @@ export const About: React.FC = () => {
           </Grid>
           <PitchesContainer container item xs={12} spacing={0} justify="center">
             {Object.values(pitches).map((pitch: Pitch, index: number) => (
-              <Grid item xs={12} lg={6} key={`pitch-${index}`}>
+              <Grid item xs={6} key={`pitch-${index}`}>
                 <PitchBox pitch={pitch} classes={borders.bottomLeftBorder} />
               </Grid>
             ))}
@@ -95,11 +95,11 @@ export const About: React.FC = () => {
       <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
         <LeftMargin xs={1} border={borderStyle} />
         <ContentContainer container item xs={10} spacing={0} direction='row' justify="center" alignItems='flex-start'>
-          <Grid item xs={12} lg={6}>
+          <Grid item xs={12}>
             <AboutTitleBoxMobile text={ABOUT_TITLE} classes={borders.bottomLeftBorder} />
             <PressBoxMobile press={press} classes={borders.bottomLeftBorder} />
           </Grid>
-          <StatsContainer container item xs={12} lg={6} spacing={0} justify="center">
+          <StatsContainer container item xs={12} spacing={0} justify="center">
             {Object.values(statsMobile).map((stat: Stat, index: number) => (
               <Grid item xs={6} key={`statMobile-${index}`}>
                 <StatBoxMobile stat={stat} classes={borders.bottomLeftBorder} />
@@ -111,7 +111,7 @@ export const About: React.FC = () => {
           </Grid>
           <PitchesContainer container item xs={12} spacing={0} justify="center">
             {Object.values(pitches).map((pitch: Pitch, index: number) => (
-              <Grid item xs={12} lg={6} key={`pitch-${index}`}>
+              <Grid item xs={12} key={`pitch-${index}`}>
                 <PitchBoxMobile pitch={pitch} classes={borders.bottomLeftBorder} />
               </Grid>
             ))}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -55,7 +55,7 @@ export const About: React.FC = () => {
   const borders = useBorders();
 
   const theme: Theme = useTheme();
-  const desktop = useMediaQuery(theme.breakpoints.up('md'));
+  const desktop = useMediaQuery(theme.breakpoints.up('lg'));
 
   if (desktop) {
     return (

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -112,9 +112,9 @@ export const theme = createMuiTheme({
     values: {
       xs: 0,
       sm: 600,
-      md: 1280,
+      md: 960,
       lg: 1280,
-      xl: 1485,
+      xl: 1920,
     },
   },
 });

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -112,7 +112,7 @@ export const theme = createMuiTheme({
     values: {
       xs: 0,
       sm: 600,
-      md: 960,
+      md: 1280,
       lg: 1280,
       xl: 1485,
     },


### PR DESCRIPTION
Improved responsiveness of desktop version of About page by liberally using vw units, so that every component on the page now scales with screen width.

While I was running today, I had the insight that this is possible. For some reason I hadn't before realized I can use vw units for everything from font sizes to box heights.

A similar update for the mobile version of the page is forthcoming.