### PR TITLE
Fix mobile About page bugs

### DIFF
--- a/src/components/HeaderMobile.tsx
+++ b/src/components/HeaderMobile.tsx
@@ -10,7 +10,7 @@ const LOGO_PATH = process.env.PUBLIC_URL + "/imgs/dOrg-logo-white.svg";
 
 const StyledAppBar = styled(AppBar)({
   height: '14.3vw',
-  width: '100vw',
+  width: '105vw',
   position: 'relative',
   zIndex: 2
 });
@@ -29,7 +29,8 @@ const StyledLogo = styled("img")({
 });
 
 const HeaderMargin = styled(Grid)({
-  maxWidth: '5.5vw',
+  maxWidth: '6vw',
+  minWidth: '4.5vw',
   height: 'inherit'
 });
 

--- a/src/components/HeaderMobile.tsx
+++ b/src/components/HeaderMobile.tsx
@@ -10,7 +10,9 @@ const LOGO_PATH = process.env.PUBLIC_URL + "/imgs/dOrg-logo-white.svg";
 
 const StyledAppBar = styled(AppBar)({
   height: '14.3vw',
-  width: '100vw'
+  width: '100vw',
+  position: 'relative',
+  zIndex: 2
 });
 
 const LogoContainer = styled(Grid)({

--- a/src/components/LeftMargin.tsx
+++ b/src/components/LeftMargin.tsx
@@ -3,6 +3,7 @@ import {styled, Grid, useTheme, Theme, useMediaQuery} from '@material-ui/core'
 
 const StyledGrid = styled(Grid)({
   maxWidth: '8vw',
+  minWidth: '4.5vw'
 });
 
 // It's a little weird using a grid here, but doing so correctly lines up box borders
@@ -21,8 +22,8 @@ export const LeftMargin: React.FC<Props> = (props: Props) => {
   const desktop = useMediaQuery(theme.breakpoints.up('lg'));
 
   return (
-    <StyledGrid item xs={props.xs} style={{height: desktop ? '116.775vw' : '144.25rem', maxWidth: desktop ? '8vw' : '5.5vw'}}>
-      <CenterLine item style={{borderBottom: props.border, height: desktop ? '57.375vw' : '47.375rem'}} />
+    <StyledGrid item xs={props.xs} style={{height: desktop ? '116.775vw' : '550vw', maxWidth: desktop ? '8vw' : '6vw'}}>
+      <CenterLine item style={{borderBottom: props.border, height: desktop ? '57.375vw' : '180.5vw'}} />
     </StyledGrid>
   );
 }

--- a/src/components/RightMargin.tsx
+++ b/src/components/RightMargin.tsx
@@ -3,7 +3,8 @@ import {styled, Grid, useTheme, Theme, useMediaQuery} from '@material-ui/core'
 import {theme} from "../theme";
 
 const StyledGrid = styled(Grid)({
-  maxWidth: '8vw'
+  maxWidth: '8vw',
+  minWidth: '4.5vw'
 });
 
 const CenterLine = styled(Grid)({
@@ -49,10 +50,10 @@ export const RightMargin: React.FC<Props> = (props: Props) => {
   const desktop = useMediaQuery(theme.breakpoints.up('lg'));
 
   return (
-    <StyledGrid item xs={props.xs} style={{borderLeft: props.border, height: desktop ? '116.775vw' : '144.25rem', maxWidth: desktop ? '8vw' : '5.5vw'}}>
+    <StyledGrid item xs={props.xs} style={{borderLeft: props.border, height: desktop ? '116.775vw' : '550vw', maxWidth: desktop ? '8vw' : '6vw'}}>
       {desktop ?
         <Accents xs={props.xs} border={props.border}/> :
-        <CenterLine item style={{borderBottom: props.border, height: '47.375rem'}} />}
+        <CenterLine item style={{borderBottom: props.border, height: '180.5vw'}} />}
     </StyledGrid>
   );
 }

--- a/src/components/about/mobile/AboutTitleBoxMobile.tsx
+++ b/src/components/about/mobile/AboutTitleBoxMobile.tsx
@@ -5,34 +5,36 @@ import { theme } from "../../../theme";
 const StyledBox = styled(Box)({
   margin: 'auto',
   width: '100%',
-  height: '11.875rem',
+  height: '45vw',
   background: 'transparent',
   boxSizing: 'border-box',
   position: 'relative'
 });
 
 const StyledText = styled(Typography)({
-  maxWidth: '19.5rem',
-  padding: '2.1rem 1.4rem',
+  maxWidth: '74vw',
+  padding: '6.5vw 5.5vw',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '1.75rem',
+  fontSize: '6.67vw',
   fontWeight: 600,
   fontStretch: "normal",
   fontStyle: "normal",
   lineHeight: 1.5,
   letterSpacing: '-0.84px',
   textAlign: "left",
-  color: theme.palette.text.primary
+  color: theme.palette.text.primary,
+  position: 'relative',
+  zIndex: 1
 });
 
 const StyledRings = styled('img')({
-  width: '12.191rem',
-  height: '12.334rem',
+  width: '46.4vw',
+  height: '47vw',
   objectFit: 'contain',
   position: 'absolute',
-  top: 0,
+  top: -3,
   right: 0,
-  zIndex: 1
+  zIndex: 0
 });
 
 interface Props {

--- a/src/components/about/mobile/CloseBoxMobile.tsx
+++ b/src/components/about/mobile/CloseBoxMobile.tsx
@@ -7,17 +7,17 @@ import {CloseButtonMobile} from "./CloseButtonMobile";
 const StyledBox = styled(Box)({
   margin: 'auto',
   width: '100%',
-  height: '25.5rem',
+  height: '98vw',
   background: theme.palette.secondary.main,
   boxSizing: 'border-box',
   position: 'relative'
 });
 
 const StyledQuote = styled(Typography)({
-  maxWidth: '19.438rem',
-  margin: '0 0 -1.125rem 0',
+  maxWidth: '74vw',
+  margin: '0 0 -4.3vw 0',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '2.25rem',
+  fontSize: '8.57vw',
   fontWeight: 300,
   fontStretch: "normal",
   fontStyle: "normal",
@@ -30,7 +30,7 @@ const StyledQuote = styled(Typography)({
 const StyledCitation = styled(Typography)({
   width: '100%',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '1.125rem',
+  fontSize: '4.3vw',
   fontWeight: 600,
   fontStretch: "normal",
   fontStyle: "normal",
@@ -41,8 +41,8 @@ const StyledCitation = styled(Typography)({
 });
 
 const StyledRings = styled('img')({
-  width: '9.064rem',
-  height: '9.171rem',
+  width: '34.53vw',
+  height: '34.94vw',
   objectFit: 'contain',
   transform: 'scaleX(-1)',
   position: 'absolute',

--- a/src/components/about/mobile/CloseButtonMobile.tsx
+++ b/src/components/about/mobile/CloseButtonMobile.tsx
@@ -6,11 +6,11 @@ import { theme } from "../../../theme";
 const StyleGrid = styled(Grid)({
   margin: 'auto',
   width: '100%',
-  height: '4.5rem',
-  padding: '1.5rem 1.5rem 1.5rem 2.5rem',
+  height: '17.15vw',
+  padding: '5.7vw 5.7vw 5.7vw 9.5vw',
   background: 'transparent',
   boxSizing: 'border-box',
-  boxShadow: '0 0.1875rem 0.375rem 0 rgba(0, 0, 0, 0.16), inset 0 0.1875rem 0.375rem 0 rgba(0, 0, 0, 0.16)',
+  boxShadow: '0 0.715vw 1.43vw 0 rgba(0, 0, 0, 0.16), inset 0 0.715vw 1.43vw 0 rgba(0, 0, 0, 0.16)',
   borderRadius: 0,
   border: 'solid 2px ' + theme.palette.text.primary,
   '&:hover': {
@@ -21,11 +21,11 @@ const StyleGrid = styled(Grid)({
 
 const StyleText = styled(Typography)({
   width: '100%',
-  height: '1rem',
+  height: '3.81vw',
   margin: 'auto',
   padding: 0,
   fontFamily: theme.typography.fontFamily,
-  fontSize: '0.938rem',
+  fontSize: '3.57vw',
   fontWeight: 'bold',
   fontStretch: "normal",
   fontStyle: "normal",
@@ -36,9 +36,9 @@ const StyleText = styled(Typography)({
 });
 
 const StyleArrow = styled('img')({
-  width: '1.5rem',
-  height: '1.5rem',
-  margin: '0 0 0 1.75rem',
+  width: '5.7vw',
+  height: '5.7vw',
+  margin: '0 0 0 6.67vw',
   padding: 0,
   objectFit: "contain"
 });

--- a/src/components/about/mobile/PitchBoxMobile.tsx
+++ b/src/components/about/mobile/PitchBoxMobile.tsx
@@ -7,8 +7,8 @@ import {hexToRGB} from "../../../utils";
 const StyledGrid = styled(Grid)({
   margin: 'auto',
   width: '100%',
-  height: '15.5rem',
-  padding: '2.5rem 1.5rem',
+  height: '59vw',
+  padding: '9.3vw 5.5vw',
   backgroundColor: 'rgba(0, 0, 0, 0.15)',
   boxSizing: 'border-box',
   '&:hover': {
@@ -19,8 +19,9 @@ const StyledGrid = styled(Grid)({
 });
 
 const StyledDetail = styled(Typography)({
+  maxWidth: '71vw',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '0.875rem',
+  fontSize: '3.33vw',
   fontWeight: 500,
   fontStretch: 'normal',
   fontStyle: 'normal',
@@ -33,9 +34,9 @@ const StyledDetail = styled(Typography)({
 const StyledPitch = styled(Typography)({
   width: '100%',
   height: '100%',
-  margin: '0.75rem 0',
+  margin: '2.85vw 0',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '1.5rem',
+  fontSize: '5.72vw',
   fontWeight: 600,
   fontStretch: "normal",
   fontStyle: "normal",
@@ -46,9 +47,9 @@ const StyledPitch = styled(Typography)({
 });
 
 const StyledIcon = styled('img')({
-  width: "3rem",
-  height: "3rem",
-  marginBottom: '1.1rem',
+  width: "11.43vw",
+  height: "11.43vw",
+  marginBottom: '4.2vw',
   objectFit: "contain",
   float: 'left'
 });

--- a/src/components/about/mobile/PitchTitleBoxMobile.tsx
+++ b/src/components/about/mobile/PitchTitleBoxMobile.tsx
@@ -6,17 +6,17 @@ import { theme } from "../../../theme";
 const StyledGrid = styled(Grid)({
   margin: 'auto',
   width: '100%',
-  height: '9.375rem',
+  height: '35.5vw',
   background: 'transparent',
   boxSizing: 'border-box',
   position: 'relative'
 });
 
 const StyledText = styled(Typography)({
-  maxWidth: '19.438rem',
-  marginLeft: '1.438rem',
+  maxWidth: '74vw',
+  marginLeft: '5.15vw',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '1.75rem',
+  fontSize: '6.67vw',
   fontWeight: 600,
   fontStretch: "normal",
   fontStyle: "normal",
@@ -27,8 +27,8 @@ const StyledText = styled(Typography)({
 });
 
 const StyledRings = styled('img')({
-  width: '12.191rem',
-  height: '12.334rem',
+  width: '46.45vw',
+  height: '47vw',
   objectFit: 'contain',
   position: 'absolute',
   top: -3,

--- a/src/components/about/mobile/PressBoxMobile.tsx
+++ b/src/components/about/mobile/PressBoxMobile.tsx
@@ -7,7 +7,7 @@ import {Article, Press} from "../../../constants/press";
 const StyledBox = styled(Box)({
   margin: 'auto',
   width: '100%',
-  height: '10.75rem',
+  height: '41vw',
   backgroundColor: theme.palette.secondary.main,
   boxSizing: 'border-box',
   position: 'relative'
@@ -19,8 +19,8 @@ const StyledGrid = styled(Grid)({
 });
 
 const StyledIcon = styled('img')({
-  width: "7.5rem",
-  height: "1.625rem",
+  width: "28.6vw",
+  height: "6.2vw",
   margin: 'auto',
   objectFit: "contain",
   background: 'transparent',
@@ -30,8 +30,8 @@ const StyledIcon = styled('img')({
 });
 
 const StyledRings = styled('img')({
-  width: '9.064rem',
-  height: '9.171rem',
+  width: '34.55vw',
+  height: '34.95vw',
   objectFit: 'contain',
   position: 'absolute',
   top: 0,

--- a/src/components/about/mobile/StatBoxMobile.tsx
+++ b/src/components/about/mobile/StatBoxMobile.tsx
@@ -14,7 +14,9 @@ const StyledBox = styled(Grid)({
   boxSizing: 'border-box',
   '&:hover': {
     backgroundColor: 'rgba(0, 0, 0, 0.15)'
-  }
+  },
+  position: 'relative',
+  zIndex: 2
 });
 
 const StyledTitle = styled(Typography)({

--- a/src/components/about/mobile/StatBoxMobile.tsx
+++ b/src/components/about/mobile/StatBoxMobile.tsx
@@ -8,8 +8,8 @@ import {mobileStatFont} from "../../../theme/styles";
 const StyledBox = styled(Grid)({
   margin: 'auto',
   width: '100%',
-  height: '8.25rem',
-  padding: '1.875rem 1.25rem',
+  height: '31.35vw',
+  padding: '7.15vw 4vw 7.15vw 4.75vw',
   backgroundColor: 'transparent',
   boxSizing: 'border-box',
   '&:hover': {
@@ -20,9 +20,9 @@ const StyledBox = styled(Grid)({
 const StyledTitle = styled(Typography)({
   width: '100%',
   height: '100%',
-  margin: '0.813rem 0 0 0',
+  margin: '3.1vw 0 0 0',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '0.813rem',
+  fontSize: '3.1vw',
   fontWeight: 500,
   fontStretch: 'normal',
   fontStyle: 'normal',
@@ -37,7 +37,7 @@ const StyledStat = styled(Typography)({
   height: "100%",
   // the design spec calls for OpenSans font here, but I am using Spartan for now
   fontFamily: mobileStatFont,
-  fontSize: "2rem",
+  fontSize: "7.15vw",
   fontWeight: "bold",
   fontStretch: "normal",
   fontStyle: "normal",
@@ -48,10 +48,12 @@ const StyledStat = styled(Typography)({
 });
 
 const StyledIcon = styled('img')({
-  width: "1.5rem",
-  height: "1.5rem",
+  width: "4.3vw",
+  height: "4.3vw",
   objectFit: "contain",
-  float: 'right'
+  float: 'right',
+  position: 'relative',
+  top: '-1vw'
 });
 
 interface Props {

--- a/src/components/about/mobile/StatBoxMobile.tsx
+++ b/src/components/about/mobile/StatBoxMobile.tsx
@@ -8,7 +8,7 @@ import {mobileStatFont} from "../../../theme/styles";
 const StyledBox = styled(Grid)({
   margin: 'auto',
   width: '100%',
-  height: '31.35vw',
+  height: '31.5vw',
   padding: '7.15vw 4vw 7.15vw 4.75vw',
   backgroundColor: 'transparent',
   boxSizing: 'border-box',

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -92,9 +92,9 @@ export const About: React.FC = () => {
     );
   } else {
     return (
-      <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
+      <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start' style={{width: '105vw'}}>
         <LeftMargin xs={1} border={borderStyle} />
-        <ContentContainer container item xs={10} spacing={0} direction='row' justify="center" alignItems='flex-start'>
+        <ContentContainer container item xs={10} spacing={0} direction='row' justify="center" alignItems='flex-start' style={{maxWidth: '91vw'}}>
           <Grid item xs={12}>
             <AboutTitleBoxMobile text={ABOUT_TITLE} classes={borders.bottomLeftBorder} />
             <PressBoxMobile press={press} classes={borders.bottomLeftBorder} />


### PR DESCRIPTION
Several updates to mobile About page. Closes #56.

- Improved responsiveness
- Fixed issue where icon was overlapping with text in StateBoxMobile
- Adjusted concentric rings graphics positioning and z-index/render order
- Changed mobile root view width to 105 because 100 was not filling screen

Question: Should mobile root view width remain at 100 and be centered? Maybe it only doesn't fill the screen on certain phones?