### PR TITLE
Add Contact Form

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.13",
     "@material-ui/core": "^4.11.2",
+    "@material-ui/icons": "^4.11.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-ga": "^3.3.0",
+    "react-hook-form": "^6.14.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1"
   },

--- a/public/imgs/circled-arrow-icon.svg
+++ b/public/imgs/circled-arrow-icon.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="140" viewBox="0 0 140 140">
+    <defs>
+        <filter id="Rectangle_50" width="140" height="140" x="0" y="0" filterUnits="userSpaceOnUse">
+            <feOffset dy="10"/>
+            <feGaussianBlur result="blur" stdDeviation="10"/>
+            <feFlood flood-color="#001047" flood-opacity=".2"/>
+            <feComposite in2="blur" operator="in"/>
+            <feComposite in="SourceGraphic"/>
+        </filter>
+        <style>
+            .cls-2{fill:none}
+        </style>
+    </defs>
+    <g id="Component_32_2" transform="translate(30 20)">
+        <g filter="url(#Rectangle_50)" transform="translate(-30 -20)">
+            <rect id="Rectangle_50-2" width="80" height="80" fill="#fff" rx="40" transform="translate(30 20)"/>
+        </g>
+        <g id="Group_334" transform="translate(-143.864 19.136)">
+            <g id="trending_flat-24px_2_" transform="translate(163)">
+                <path id="Path_44" d="M0 0h41.729v41.729H0z" class="cls-2"/>
+                <path id="Path_45" fill="#1aaf71" d="M36.035 14.955L29.08 8v5.216H3v3.477h26.08v5.217z" transform="translate(2.216 5.91)"/>
+            </g>
+        </g>
+        <g id="Rectangle_475" fill="none" stroke="#1aaf71" transform="translate(7 7)">
+            <rect width="66" height="66" stroke="none" rx="33"/>
+            <rect width="65" height="65" x=".5" y=".5" class="cls-2" rx="32.5"/>
+        </g>
+    </g>
+</svg>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
 import { useForm } from "react-hook-form";
-import {ButtonBase, Grid, makeStyles, styled, TextField, Typography} from '@material-ui/core'
+import {ButtonBase, Grid, makeStyles, Snackbar, styled, TextField, Typography} from '@material-ui/core'
 import { theme } from "../theme";
 import {AccountCircleTwoTone, EmailTwoTone, RateReviewTwoTone} from '@material-ui/icons';
 
+// Input placeholders and button image
 const NAME_PLACEHOLDER = 'Your Name';
 const EMAIL_PLACEHOLDER = 'Email';
 const MESSAGE_PLACEHOLDER = 'Message';
 const SUBMIT_BUTTON_IMG_PATH = "/imgs/circled-arrow-icon.svg";
+
+// Form input validation parameters and error messages
 const MAX_NAME_LENGTH = 100;
 const MAX_EMAIL_LENGTH = 100;
 const MAX_MESSAGE_LENGTH = 2000;
@@ -17,6 +20,10 @@ const ERROR_EMAIL_REQUIRED = 'Your email is required';
 const ERROR_MESSAGE_REQUIRED = 'Tell us what we can do for you';
 const ERROR_INVALID_EMAIL = 'Enter a valid email address';
 const ERROR_EXCEEDS_LENGTH = (chars: number, max: number) => {return `${chars}/${max} characters`};
+
+// Text that appears in SnackBar upon form submission
+const SUCCESS_TEXT = 'Submission succeeded!';
+const FAIL_TEXT = 'Submission failed :(';
 
 const StyledGrid = styled(Grid)({
   margin: 'auto',
@@ -141,6 +148,44 @@ const StyledError = styled(Typography)({
   left: '3vw'
 });
 
+const useSuccessSnackBarStyle = makeStyles({
+  root: {
+    backgroundColor: theme.palette.primary.main,
+    position: 'relative',
+    right: '17.5vw',
+    bottom: '7vw'
+  },
+  message: {
+    paddingLeft: '4vw',
+    fontFamily: theme.typography.fontFamily,
+    fontSize: '1vw',
+    fontWeight: 600,
+    fontStretch: "normal",
+    fontStyle: "normal",
+    letterSpacing: '-0.45px',
+    color: theme.palette.text.secondary,
+  },
+});
+
+const useFailsureSnackBarStyle = makeStyles({
+  root: {
+    backgroundColor: '#FF1744',
+    position: 'relative',
+    right: '17.5vw',
+    bottom: '7vw'
+  },
+  message: {
+    fontFamily: theme.typography.fontFamily,
+    fontSize: '1vw',
+    fontWeight: 600,
+    fontStretch: "normal",
+    fontStyle: "normal",
+    letterSpacing: '-0.45px',
+    color: theme.palette.text.primary,
+  },
+});
+
+
 interface Props {
   classes?: string;
 }
@@ -155,7 +200,7 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
 
   // FORM HOOK
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, errors, handleSubmit, formState: {isSubmitSuccessful}} = useForm<IFormInput>();
+  const { register, errors, handleSubmit } = useForm<IFormInput>();
 
   // INPUT STATE HOOKS
   const [name, setName] = React.useState('');
@@ -169,6 +214,19 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
   const [message, setMessage] = React.useState('');
   const handleMessageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setMessage(event.target.value);
+  };
+
+  // SUCCESS AND FAILURE MESSAGES
+  const successSnackBarStyle = useSuccessSnackBarStyle();
+  const failureSnackBarStyle = useFailsureSnackBarStyle();
+  const [successOpen, setSuccessOpen] = React.useState(false);
+  const [failOpen, setFailOpen] = React.useState(false);
+  const handleClose = (event: React.SyntheticEvent | React.MouseEvent, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setSuccessOpen(false);
+    setFailOpen(false);
   };
 
   // FORM SUBMISSION
@@ -197,26 +255,22 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
   }
 
   const onSubmit = (data: IFormInput) => {
-    if (isSubmitSuccessful) {
-      const submittedData: IFormInput = {...data}
+    const submittedData: IFormInput = {...data}
 
-      // the following two lines should be removed before final publish:
-      console.log(submittedData);
-      resetInputs();
+    // the following two lines should be removed before final publish:
+    console.log(submittedData);
+    setSuccessOpen(true);
+    resetInputs();
 
-      // The following lines should be uncommented before final publish:
-      // sendSubmission(submittedData)
-      //   .then(() => {
-      //     console.log('success')
-      //     resetInputs();
-      //   })
-      //   .catch(error => {
-      //     console.log('error')
-      //   });
-
-    } else {
-      console.log(data);
-    }
+    // The following lines should be uncommented before final publish:
+    // sendSubmission(submittedData)
+    //   .then(() => {
+    //     setSuccessOpen(true);
+    //     resetInputs();
+    //   })
+    //   .catch(error => {
+    //     setFailOpen(true);
+    //   });
   };
 
   // CONDITIONAL STYLING
@@ -284,6 +338,18 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
         </StyledSubmitButton>
       </form>
       <StyledRings src='imgs/concentric-rings-right.svg' alt={'concentric rings flourish'} />
+      <Snackbar anchorOrigin={{vertical: 'bottom', horizontal: 'right',}}
+        open={successOpen}
+        autoHideDuration={6000}
+        onClose={handleClose}
+        message={SUCCESS_TEXT}
+        ContentProps={{classes: successSnackBarStyle}} />
+      <Snackbar anchorOrigin={{vertical: 'bottom', horizontal: 'right',}}
+        open={failOpen}
+        autoHideDuration={6000}
+        onClose={handleClose}
+        message={FAIL_TEXT}
+        ContentProps={{classes: failureSnackBarStyle}} />
     </StyledGrid>
   );
 }

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,189 @@
+import React from 'react'
+import { useForm } from "react-hook-form";
+import {ButtonBase, Grid, styled, TextField} from '@material-ui/core'
+import { theme } from "../theme";
+import {AccountCircleTwoTone, EmailTwoTone, RateReviewTwoTone} from '@material-ui/icons';
+
+const NAME_PLACEHOLDER = 'Your Name';
+const EMAIL_PLACEHOLDER = 'Email';
+const MESSAGE_PLACEHOLDER = 'Message';
+const SUBMIT_BUTTON_IMG_PATH = "/imgs/circled-arrow-icon.svg";
+
+const StyledGrid = styled(Grid)({
+  margin: 'auto',
+  width: '100%',
+  height: '57.375vw',
+  background: theme.palette.secondary.main,
+  boxSizing: 'border-box',
+  position: 'relative'
+});
+
+const InputContainer = styled(Grid)({
+  width: '34vw',
+  height: '5vw',
+  padding: '0.7vw 1.5vw',
+  marginBottom: '1.875vw',
+  boxSizing: 'border-box',
+  boxShadow: '0 0.625vw 1.25vw 0 rgba(0, 0, 0, 0.16)',
+  backgroundColor: '#FFFFFF'
+});
+
+const StyledIconWrapper = styled(Grid)({
+  width: '1.25vw',
+  height: '3.6vw',
+  paddingRight: '1.5vw',
+  fontSize: '1.25vw',
+  color: theme.palette.secondary.main,
+  position: 'relative',
+  top: '-0.2vw'
+});
+
+const StyledTextField = styled(TextField)({
+  width: '29.5vw',
+  height: '3.6vw',
+  border: 'none',
+  backgroundColor: '#FFFFFF',
+  '& input.MuiInput-input': {
+    fontFamily: theme.typography.fontFamily,
+    fontSize: '0.938vw',
+    fontWeight: 600,
+    fontStretch: "normal",
+    fontStyle: "normal",
+    lineHeight: 1.5,
+    letterSpacing: '-0.45px',
+    textAlign: "left",
+    color: theme.palette.primary.main
+  },
+  '& label.MuiInputLabel-root': {
+    fontFamily: theme.typography.fontFamily,
+    fontSize: '0.938vw',
+    fontWeight: 600,
+    fontStretch: "normal",
+    fontStyle: "normal",
+    letterSpacing: '-0.45px',
+    color: theme.palette.primary.main
+  },
+  '& label.Mui-focused': {
+    fontSize: '0.8vw',
+    fontWeight: 'normal',
+    fontStretch: "normal",
+    fontStyle: "normal",
+    lineHeight: 'normal',
+    letterSpacing: 'normal',
+    color: theme.palette.text.secondary,
+  }
+});
+
+const StyledSubmitButton = styled(ButtonBase)({
+  width: "5vw",
+  height: "5vw",
+  float: 'right',
+  borderRadius: '50%'
+});
+
+const StyledSubmitIcon = styled('img')({
+  objectFit: "contain",
+  position: 'relative',
+  top: '0.5vw',
+  borderRadius: '50%'
+});
+
+const StyledRings = styled('img')({
+  width: '13.524vw',
+  height: '13.683vw',
+  objectFit: 'contain',
+  transform: 'rotate(-90deg)',
+  position: 'absolute',
+  bottom: -1,
+  left: 0
+})
+
+interface Props {
+  classes?: string;
+}
+
+interface IFormInput {
+  name: string;
+  email: string;
+  message: string;
+}
+
+export const ContactForm: React.FC<Props> = (props: Props) => {
+
+  // FORM HOOKS
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const { register, errors, handleSubmit } = useForm<IFormInput>();
+
+  const onSubmit = (data: IFormInput) => { console.log(data) };
+
+  const [name, setName] = React.useState('');
+  const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setName(event.target.value);
+  };
+
+  const [email, setEmail] = React.useState('');
+  const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(event.target.value);
+  };
+
+  const [message, setMessage] = React.useState('');
+  const handleMessageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setMessage(event.target.value);
+  };
+
+  // CONDITIONAL STYLING
+  const unfocusedLabelColor = (val: string) => {
+    if(val === '') {
+      return theme.palette.primary.main;
+    }
+    return theme.palette.text.secondary;
+  }
+
+  return (
+    <StyledGrid container className={props.classes} direction='column' justify='center' alignItems='center'>
+      <form onSubmit={handleSubmit(onSubmit)} method='post'>
+
+        <InputContainer container direction='row' justify='flex-start' alignItems='center'>
+          <StyledIconWrapper container item justify='center' alignItems='center'>
+            <AccountCircleTwoTone fontSize='inherit'/>
+          </StyledIconWrapper>
+          <Grid item>
+            <StyledTextField id='name' name='name' label={NAME_PLACEHOLDER} value={name}
+              onChange={handleNameChange}
+              InputProps={{disableUnderline: true}}
+              inputRef={register({required: true, maxLength: 100})}/>
+          </Grid>
+        </InputContainer>
+        <InputContainer container direction='row' justify='flex-start' alignItems='center'>
+          <StyledIconWrapper container item justify='center' alignItems='center'>
+            <EmailTwoTone fontSize='inherit'/>
+          </StyledIconWrapper>
+          <Grid item>
+            <StyledTextField id='email' name='email' label={EMAIL_PLACEHOLDER} value={email}
+              onChange={handleEmailChange}
+              InputProps={{disableUnderline: true}}
+              inputRef={register({required: true, maxLength: 100, pattern: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i})} />
+          </Grid>
+        </InputContainer>
+
+        <InputContainer container direction='row' justify='flex-start' alignItems='flex-start' style={{height: '15.375vw'}}>
+          <StyledIconWrapper container item justify='center' alignItems='center'>
+            <RateReviewTwoTone fontSize='inherit'/>
+          </StyledIconWrapper>
+          <Grid item style={{height: '13.975vw'}}>
+            <StyledTextField id='message' name='message' multiline label={MESSAGE_PLACEHOLDER} value={message}
+              onChange={handleMessageChange}
+              InputProps={{disableUnderline: true}}
+              inputRef={register({required: true, maxLength: 1000})}
+              style={{height: 'inherit'}} />
+          </Grid>
+        </InputContainer>
+
+        <StyledSubmitButton type='submit'>
+          <StyledSubmitIcon src={SUBMIT_BUTTON_IMG_PATH} />
+        </StyledSubmitButton>
+      </form>
+      <StyledRings src='imgs/concentric-rings-right.svg' alt={'concentric rings flourish'} />
+    </StyledGrid>
+  );
+}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { useForm } from "react-hook-form";
-import {ButtonBase, Grid, styled, TextField} from '@material-ui/core'
+import {ButtonBase, Grid, makeStyles, styled, TextField} from '@material-ui/core'
 import { theme } from "../theme";
 import {AccountCircleTwoTone, EmailTwoTone, RateReviewTwoTone} from '@material-ui/icons';
+import {borderStyle, borderStyles} from "../theme/styles";
 
 const NAME_PLACEHOLDER = 'Your Name';
 const EMAIL_PLACEHOLDER = 'Email';
@@ -74,6 +75,25 @@ const StyledTextField = styled(TextField)({
   }
 });
 
+const useLabelColors = makeStyles({
+  primary: {
+    '& label.MuiInputLabel-root': {
+      color: theme.palette.primary.main
+    },
+    '& label.Mui-focused': {
+      color: theme.palette.text.secondary,
+    }
+  },
+  secondary: {
+    '& label.MuiInputLabel-root': {
+      color: theme.palette.text.secondary
+    },
+    '& label.Mui-focused': {
+      color: theme.palette.text.secondary,
+    }
+  },
+});
+
 const StyledSubmitButton = styled(ButtonBase)({
   width: "5vw",
   height: "5vw",
@@ -116,27 +136,27 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
 
   const onSubmit = (data: IFormInput) => { console.log(data) };
 
+  // INPUT STATE HOOKS
   const [name, setName] = React.useState('');
   const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setName(event.target.value);
   };
-
   const [email, setEmail] = React.useState('');
   const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(event.target.value);
   };
-
   const [message, setMessage] = React.useState('');
   const handleMessageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setMessage(event.target.value);
   };
 
-  // CONDITIONAL STYLING
+  // CONDITIONAL STYLING --> will use to keep label green when input has content
+  const labelColors = useLabelColors();
   const unfocusedLabelColor = (val: string) => {
     if(val === '') {
-      return theme.palette.primary.main;
+      return labelColors.primary;
     }
-    return theme.palette.text.secondary;
+    return labelColors.secondary;
   }
 
   return (
@@ -151,7 +171,8 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
             <StyledTextField id='name' name='name' label={NAME_PLACEHOLDER} value={name}
               onChange={handleNameChange}
               InputProps={{disableUnderline: true}}
-              inputRef={register({required: true, maxLength: 100})}/>
+              inputRef={register({required: true, maxLength: 100})}
+              className={unfocusedLabelColor(name)}/>
           </Grid>
         </InputContainer>
         <InputContainer container direction='row' justify='flex-start' alignItems='center'>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -222,7 +222,7 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
             <RateReviewTwoTone fontSize='inherit'/>
           </StyledIconWrapper>
           <Grid item style={{height: '13.975vw'}}>
-            <StyledTextField id='message' name='message' multiline rowsMax={18} label={MESSAGE_PLACEHOLDER} value={message}
+            <StyledTextField id='message' name='message' multiline rowsMax={9} label={MESSAGE_PLACEHOLDER} value={message}
               onChange={handleMessageChange}
               InputProps={{disableUnderline: true}}
               inputRef={register({required: true, maxLength: MAX_MESSAGE_LENGTH})}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -153,11 +153,9 @@ interface IFormInput {
 
 export const ContactForm: React.FC<Props> = (props: Props) => {
 
-  // FORM HOOKS
+  // FORM HOOK
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, errors, handleSubmit } = useForm<IFormInput>();
-
-  const onSubmit = (data: IFormInput) => { console.log(data) };
+  const { register, errors, handleSubmit, formState: {isSubmitSuccessful}} = useForm<IFormInput>();
 
   // INPUT STATE HOOKS
   const [name, setName] = React.useState('');
@@ -171,6 +169,54 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
   const [message, setMessage] = React.useState('');
   const handleMessageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setMessage(event.target.value);
+  };
+
+  // FORM SUBMISSION
+  const resetInputs = () => {
+    setName('');
+    setEmail('');
+    setMessage('');
+  }
+
+  const sendSubmission = async (data: IFormInput) => {
+    return fetch(
+      "https://api.airtable.com/v0/appro4l8TqwcZvFsC/Contact%20Form",
+      {
+        method: "post",
+        headers: new Headers({
+          Authorization: "Bearer keyhfYL0UX5ysZchd",
+          "Content-Type": "application/json"
+        }),
+        body: JSON.stringify({ records: [{ fields: {
+          Name: data.name,
+          Email: data.email,
+          Message: data.message
+        }}]})
+      }
+    )
+  }
+
+  const onSubmit = (data: IFormInput) => {
+    if (isSubmitSuccessful) {
+      const submittedData: IFormInput = {...data}
+
+      // the following two lines should be removed before final publish:
+      console.log(submittedData);
+      resetInputs();
+
+      // The following lines should be uncommented before final publish:
+      // sendSubmission(submittedData)
+      //   .then(() => {
+      //     console.log('success')
+      //     resetInputs();
+      //   })
+      //   .catch(error => {
+      //     console.log('error')
+      //   });
+
+    } else {
+      console.log(data);
+    }
   };
 
   // CONDITIONAL STYLING

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,14 +1,22 @@
 import React from 'react'
 import { useForm } from "react-hook-form";
-import {ButtonBase, Grid, makeStyles, styled, TextField} from '@material-ui/core'
+import {ButtonBase, Grid, makeStyles, styled, TextField, Typography} from '@material-ui/core'
 import { theme } from "../theme";
 import {AccountCircleTwoTone, EmailTwoTone, RateReviewTwoTone} from '@material-ui/icons';
-import {borderStyle, borderStyles} from "../theme/styles";
 
 const NAME_PLACEHOLDER = 'Your Name';
 const EMAIL_PLACEHOLDER = 'Email';
 const MESSAGE_PLACEHOLDER = 'Message';
 const SUBMIT_BUTTON_IMG_PATH = "/imgs/circled-arrow-icon.svg";
+const MAX_NAME_LENGTH = 100;
+const MAX_EMAIL_LENGTH = 100;
+const MAX_MESSAGE_LENGTH = 2000;
+const EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;
+const ERROR_NAME_REQUIRED = 'Your name is required';
+const ERROR_EMAIL_REQUIRED = 'Your email is required';
+const ERROR_MESSAGE_REQUIRED = 'Tell us what we can do for you';
+const ERROR_INVALID_EMAIL = 'Enter a valid email address';
+const ERROR_EXCEEDS_LENGTH = (chars: number, max: number) => {return `${chars}/${max} characters`};
 
 const StyledGrid = styled(Grid)({
   margin: 'auto',
@@ -26,7 +34,8 @@ const InputContainer = styled(Grid)({
   marginBottom: '1.875vw',
   boxSizing: 'border-box',
   boxShadow: '0 0.625vw 1.25vw 0 rgba(0, 0, 0, 0.16)',
-  backgroundColor: '#FFFFFF'
+  backgroundColor: '#FFFFFF',
+  position: 'relative'
 });
 
 const StyledIconWrapper = styled(Grid)({
@@ -118,6 +127,20 @@ const StyledRings = styled('img')({
   left: 0
 })
 
+const StyledError = styled(Typography)({
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '0.8vw',
+  fontWeight: 'normal',
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 'normal',
+  letterSpacing: 'normal',
+  color: 'red',
+  position: 'absolute',
+  bottom: 0,
+  left: '3vw'
+});
+
 interface Props {
   classes?: string;
 }
@@ -150,7 +173,7 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
     setMessage(event.target.value);
   };
 
-  // CONDITIONAL STYLING --> will use to keep label green when input has content
+  // CONDITIONAL STYLING
   const labelColors = useLabelColors();
   const unfocusedLabelColor = (val: string) => {
     if(val === '') {
@@ -171,10 +194,13 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
             <StyledTextField id='name' name='name' label={NAME_PLACEHOLDER} value={name}
               onChange={handleNameChange}
               InputProps={{disableUnderline: true}}
-              inputRef={register({required: true, maxLength: 100})}
-              className={unfocusedLabelColor(name)}/>
+              inputRef={register({required: true, maxLength: MAX_NAME_LENGTH})}
+              className={unfocusedLabelColor(name)} />
           </Grid>
+          {errors.name?.type === "required" && <StyledError>{ERROR_NAME_REQUIRED}</StyledError>}
+          {errors.name?.type === "maxLength" && <StyledError>{ERROR_EXCEEDS_LENGTH(name.length, MAX_NAME_LENGTH)}</StyledError>}
         </InputContainer>
+
         <InputContainer container direction='row' justify='flex-start' alignItems='center'>
           <StyledIconWrapper container item justify='center' alignItems='center'>
             <EmailTwoTone fontSize='inherit'/>
@@ -183,8 +209,12 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
             <StyledTextField id='email' name='email' label={EMAIL_PLACEHOLDER} value={email}
               onChange={handleEmailChange}
               InputProps={{disableUnderline: true}}
-              inputRef={register({required: true, maxLength: 100, pattern: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i})} />
+              inputRef={register({required: true, maxLength: MAX_EMAIL_LENGTH, pattern: EMAIL_PATTERN})}
+              className={unfocusedLabelColor(name)} />
           </Grid>
+          {errors.email?.type === "required" && <StyledError>{ERROR_EMAIL_REQUIRED}</StyledError>}
+          {errors.email?.type === "maxLength" && <StyledError>{ERROR_EXCEEDS_LENGTH(email.length, MAX_EMAIL_LENGTH)}</StyledError>}
+          {errors.email?.type === "pattern" && <StyledError>{ERROR_INVALID_EMAIL}</StyledError>}
         </InputContainer>
 
         <InputContainer container direction='row' justify='flex-start' alignItems='flex-start' style={{height: '15.375vw'}}>
@@ -192,12 +222,15 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
             <RateReviewTwoTone fontSize='inherit'/>
           </StyledIconWrapper>
           <Grid item style={{height: '13.975vw'}}>
-            <StyledTextField id='message' name='message' multiline label={MESSAGE_PLACEHOLDER} value={message}
+            <StyledTextField id='message' name='message' multiline rowsMax={18} label={MESSAGE_PLACEHOLDER} value={message}
               onChange={handleMessageChange}
               InputProps={{disableUnderline: true}}
-              inputRef={register({required: true, maxLength: 1000})}
-              style={{height: 'inherit'}} />
+              inputRef={register({required: true, maxLength: MAX_MESSAGE_LENGTH})}
+              style={{height: 'inherit'}}
+              className={unfocusedLabelColor(name)} />
           </Grid>
+          {errors.message?.type === "required" && <StyledError>{ERROR_MESSAGE_REQUIRED}</StyledError>}
+          {errors.message?.type === "maxLength" && <StyledError>{ERROR_EXCEEDS_LENGTH(message.length, MAX_MESSAGE_LENGTH)}</StyledError>}
         </InputContainer>
 
         <StyledSubmitButton type='submit'>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -4,6 +4,10 @@ import {ButtonBase, Grid, makeStyles, Snackbar, styled, TextField, Typography} f
 import { theme } from "../theme";
 import {AccountCircleTwoTone, EmailTwoTone, RateReviewTwoTone} from '@material-ui/icons';
 
+// Airtable integration
+const AIRTABLE_URL = 'https://api.airtable.com/PATH';
+const AIRTABLE_CREDENTIAL = 'Bearer keyXXXXXXXXX';
+
 // Input placeholders and button image
 const NAME_PLACEHOLDER = 'Your Name';
 const EMAIL_PLACEHOLDER = 'Email';
@@ -238,11 +242,11 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
 
   const sendSubmission = async (data: IFormInput) => {
     return fetch(
-      "https://api.airtable.com/v0/appro4l8TqwcZvFsC/Contact%20Form",
+      AIRTABLE_URL,
       {
         method: "post",
         headers: new Headers({
-          Authorization: "Bearer keyhfYL0UX5ysZchd",
+          Authorization: AIRTABLE_CREDENTIAL,
           "Content-Type": "application/json"
         }),
         body: JSON.stringify({ records: [{ fields: {
@@ -257,7 +261,7 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
   const onSubmit = (data: IFormInput) => {
     const submittedData: IFormInput = {...data}
 
-    // the following two lines should be removed before final publish:
+    // the following three lines should be removed before final publish:
     console.log(submittedData);
     setSuccessOpen(true);
     resetInputs();

--- a/src/components/ContactTitleBox.tsx
+++ b/src/components/ContactTitleBox.tsx
@@ -6,21 +6,21 @@ import { theme } from "../theme";
 const StyledBox = styled(Box)({
   margin: 'auto',
   width: '100%',
-  height: '57.375rem',
+  height: '57.375vw',
   background: 'transparent',
   boxSizing: 'border-box'
 });
 
 const TextContainer = styled(Box)({
-  padding: '6.75rem 1.75rem',
+  padding: '6.75vw 1.75vw',
   background: 'transparent',
   boxSizing: 'border-box'
 });
 
 const StyledTitle = styled(Typography)({
-  maxWidth: '36rem',
+  maxWidth: '36vw',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '3.25rem',
+  fontSize: '3.25vw',
   fontWeight: 600,
   fontStretch: "normal",
   fontStyle: "normal",
@@ -31,9 +31,9 @@ const StyledTitle = styled(Typography)({
 });
 
 const StyledSubTitle = styled(Typography)({
-  margin: '4.25rem 0 0 0',
+  margin: '4.25vw 0 0 0',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '2rem',
+  fontSize: '2vw',
   fontWeight: 600,
   fontStretch: "normal",
   fontStyle: "normal",
@@ -44,9 +44,9 @@ const StyledSubTitle = styled(Typography)({
 });
 
 const StyledInstructions = styled(Typography)({
-  maxWidth: '28.875rem',
+  maxWidth: '28.875vw',
   fontFamily: theme.typography.fontFamily,
-  fontSize: '1rem',
+  fontSize: '1vw',
   fontWeight: 'normal',
   fontStretch: "normal",
   fontStyle: "normal",

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -4,6 +4,7 @@ import {ContactTitleBox} from "../components/ContactTitleBox";
 import {RightMargin} from "../components/RightMargin";
 import {LeftMargin} from "../components/LeftMargin";
 import {borderStyle} from "../theme/styles";
+import {ContactForm} from "../components/ContactForm";
 
 const TITLE = 'Get in Touch.';
 const SUBTITLE = 'Not sure where to start?';
@@ -23,11 +24,11 @@ export const Contact: React.FC = () => {
     <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
       <LeftMargin xs={1} border={borderStyle} />
       <ContentContainer container item xs={10} spacing={0} direction='row' justify="center" alignItems='flex-start'>
-        <Grid item xs={12} lg={6}>
+        <Grid item xs={6}>
           <ContactTitleBox title={TITLE} subtitle={SUBTITLE} instructions={INSTRUCTIONS} />
         </Grid>
-        <Grid item xs={12} lg={6}>
-          <div />
+        <Grid item xs={6}>
+          <ContactForm />
         </Grid>
       </ContentContainer>
       <RightMargin xs={1} border={borderStyle} />

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -84,6 +84,17 @@ export const theme = createMuiTheme({
           borderWidth: 0
         }
       },
+      multiline: {
+        fontFamily: `'Spartan', sans-serif`,
+        fontSize: '0.938vw',
+        fontWeight: 600,
+        fontStretch: "normal",
+        fontStyle: "normal",
+        lineHeight: 1.5,
+        letterSpacing: '-0.45px',
+        textAlign: "left",
+        color: "#001047"
+      }
     },
     MuiLink: {
       root: {

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -93,7 +93,8 @@ export const theme = createMuiTheme({
         lineHeight: 1.5,
         letterSpacing: '-0.45px',
         textAlign: "left",
-        color: "#001047"
+        color: "#001047",
+        alignItems: 'flex-start'
       }
     },
     MuiLink: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,6 +1580,7 @@ __metadata:
     "@fortawesome/free-solid-svg-icons": ^5.15.1
     "@fortawesome/react-fontawesome": ^0.1.13
     "@material-ui/core": ^4.11.2
+    "@material-ui/icons": ^4.11.2
     "@types/node": ^12.0.0
     "@types/react": ^16.9.53
     "@types/react-dom": ^16.9.8
@@ -1602,6 +1603,7 @@ __metadata:
     react: ^17.0.1
     react-dom: ^17.0.1
     react-ga: ^3.3.0
+    react-hook-form: ^6.14.0
     react-refresh: ^0.9.0
     react-router-dom: ^5.2.0
     react-scripts: 4.0.1
@@ -2025,6 +2027,23 @@ __metadata:
     "@types/react":
       optional: true
   checksum: fe89aa37a5117873b467923f0b16189bcd795fb28aa422ec678ff781b14a1351bea8db6fde9cec0a76f49a38ca9ded1fc4f82705d42ac27e6ede787d3412c584
+  languageName: node
+  linkType: hard
+
+"@material-ui/icons@npm:^4.11.2":
+  version: 4.11.2
+  resolution: "@material-ui/icons@npm:4.11.2"
+  dependencies:
+    "@babel/runtime": ^7.4.4
+  peerDependencies:
+    "@material-ui/core": ^4.0.0
+    "@types/react": ^16.8.6 || ^17.0.0
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 0f5f70d10581e50e96dadf4d7cd5ef2acdc135e460a74eb29fdeecd5fd98fb1caae9692979997438a9606c193b52b6e0186cabf57af1352fa92221b7eb71ea83
   languageName: node
   linkType: hard
 
@@ -14183,6 +14202,15 @@ fsevents@~2.1.2:
     prop-types: ^15.6.0
     react: ^15.6.2 || ^16.0 || ^17
   checksum: fe3dc0a7679b3a52df3944660f2b1f353ee5d24f73e4bdb88c8323e012e1042ef3c2c1a6e432d3c6e3196861162925ff9f5ba515a8112e11187d21d8a00cc863
+  languageName: node
+  linkType: hard
+
+"react-hook-form@npm:^6.14.0":
+  version: 6.14.0
+  resolution: "react-hook-form@npm:6.14.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17
+  checksum: d2c7023ed8f506aab0fcd95cb24b20df9ef2da6846269686de5072ab7eb0a5fb430be513ca8054503698f92a96f020cbac5711567936bb1dfc25992e01804324
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Added contact form component. Closes #46.

The success/failure toasts could use a design overhaul. I added some custom styling but it could be better.

When you submit the form, the data is not sent anywhere. The code is written to do so, but I commented it out to prevent test submissions from populating our production airtable.

There is a bug with the submit button that is caused by the svg image having a transparent background. The visible part of the image isn't even centered in the actual image dimensions. If you change the background color of the image, you can see what I'm talking about. I partially compensated for this by using relative positioning and border radius. Still, the cursor will become a pointer when it is well below the submit button. We need to crop the svg file so we retain only the part we care about.

I added two new dependencies: react-hook-form and the dependency for Material UI icons.