### PR TITLE
Add desktop Careers page Current Openings component #70

### DIFF
--- a/src/components/about/desktop/CloseButton.tsx
+++ b/src/components/about/desktop/CloseButton.tsx
@@ -16,6 +16,9 @@ const StyleGrid = styled(Grid)({
   '&:hover': {
     border: 'solid 1px ' + theme.palette.text.primary,
   },
+  '&:focus': {
+    border: 'solid 1px ' + theme.palette.text.primary,
+  },
   zIndex: 1
 });
 
@@ -46,13 +49,14 @@ const StyleArrow = styled('img')({
 interface Props {
   text: string;
   handleClick: () => void
+  classes?: string;
 }
 
 export const CloseButton: React.FC<Props> = (props: Props) => {
 
   return (
     <ButtonBase onClick={() => props.handleClick()}>
-      <StyleGrid container spacing={0} justify={'space-between'} alignItems={'center'}>
+      <StyleGrid className={props.classes} container spacing={0} justify={'space-between'} alignItems={'center'}>
         <Grid item>
           <StyleText>{props.text}</StyleText>
         </Grid>

--- a/src/components/careers/desktop/CurrentOpeningAccordion.tsx
+++ b/src/components/careers/desktop/CurrentOpeningAccordion.tsx
@@ -100,8 +100,8 @@ export const CurrentOpeningAccordion: React.FC<Props> = (props: Props) => {
 
   return (
     <Accordion classes={accordionStyle} className={props.classes} expanded={props.expanded} onChange={props.onChange}
-      style={{borderBottom: props.border, width: 'inherit'}}>
-      <AccordionSummary expandIcon={<ExpandIcon/>} aria-controls="panel1bh-content" id="panel1bh-header">
+      style={{borderBottom: props.border, width: 'inherit', margin: 0}}>
+      <AccordionSummary expandIcon={<ExpandIcon/>} aria-controls={`${props.opening.id}-content`} id={`${props.opening.id}-header`}>
         <SummaryGrid container direction='row' justify={'space-between'} alignItems={'center'}>
           <Grid item xs={6} container direction='row' justify={'flex-start'} alignItems={'center'} style={{height: 'inherit'}}>
             <StyledIcon src={icon} alt={'icon'}/>

--- a/src/components/careers/desktop/CurrentOpeningAccordion.tsx
+++ b/src/components/careers/desktop/CurrentOpeningAccordion.tsx
@@ -1,0 +1,124 @@
+import React from 'react'
+import {Accordion, AccordionDetails, AccordionSummary, Grid, makeStyles, styled, Typography} from '@material-ui/core'
+import {theme} from "../../../theme";
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import {Opening, Role} from "../../../constants/openings";
+
+const SummaryGrid = styled(Grid)({
+  width: '100%',
+  height: '5vw',
+  boxSizing: 'border-box',
+  background: 'transparent'
+});
+
+const StyledIcon = styled('img')({
+  marginLeft: '2.625vw',
+  marginRight: '2.125vw',
+  width: "1.75vw",
+  height: "1.75vw",
+  objectFit: "contain",
+  float: 'left'
+});
+
+const StyledTitle = styled(Typography)({
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '1.25vw',
+  fontWeight: 600,
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1,
+  letterSpacing: '-1px',
+  textAlign: "left",
+  color: theme.palette.text.primary
+});
+
+const StyledLocation = styled(Typography)({
+  marginRight: '2vw',
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '0.75vw',
+  fontWeight: 500,
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1,
+  letterSpacing: 'normal',
+  textAlign: "right",
+  color: theme.palette.text.primary
+});
+
+const ExpandIconWrapper = styled(Grid)({
+  fontSize: '2vw',
+  color: 'rgba(255, 255, 255, 0.5)'
+});
+
+const StyledDescription = styled(Typography)({
+  width: '49.3vw',
+  marginTop: '-0.75vw',
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '0.75vw',
+  fontWeight: 500,
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 2.33,
+  letterSpacing: 'normal',
+  textAlign: "left",
+  color: theme.palette.text.primary
+});
+
+
+const useAccordionStyle = makeStyles({
+  root: {
+    background: 'transparent'
+  },
+  expanded: {
+    backgroundColor: '#03284d'
+  }
+});
+
+interface Props {
+  opening: Opening;
+  expanded: boolean;
+  onChange: (event: React.ChangeEvent<{}>, isExpanded: boolean) => void; //eslint-disable-line
+  classes?: string;
+  border?: string;
+}
+
+export const ExpandIcon: React.FC = () => {
+  return (
+    <ExpandIconWrapper container item justify='center' alignItems='center'>
+      <ExpandMoreIcon fontSize='inherit'/>
+    </ExpandIconWrapper>
+  );
+}
+
+export const CurrentOpeningAccordion: React.FC<Props> = (props: Props) => {
+
+  const accordionStyle = useAccordionStyle();
+
+  const icon = props.opening.role === Role.design ? 'imgs/pentipicon.svg'
+    : props.opening.role === Role.frontend ? 'imgs/arrowbracketsicon.svg'
+      : 'imgs/gearicon.svg'
+
+  return (
+    <Accordion classes={accordionStyle} className={props.classes} expanded={props.expanded} onChange={props.onChange}
+      style={{borderBottom: props.border, width: 'inherit'}}>
+      <AccordionSummary expandIcon={<ExpandIcon/>} aria-controls="panel1bh-content" id="panel1bh-header">
+        <SummaryGrid container direction='row' justify={'space-between'} alignItems={'center'}>
+          <Grid item xs={6} container direction='row' justify={'flex-start'} alignItems={'center'} style={{height: 'inherit'}}>
+            <StyledIcon src={icon} alt={'icon'}/>
+            <StyledTitle>{props.opening.title}</StyledTitle>
+          </Grid>
+          <Grid item xs={6}>
+            <StyledLocation>{props.opening.location}</StyledLocation>
+          </Grid>
+        </SummaryGrid>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Grid container direction='row' justify={'center'} alignItems={'flex-start'} style={{width: '100%'}}>
+          <Grid item>
+            <StyledDescription>{props.opening.description}</StyledDescription>
+          </Grid>
+        </Grid>
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/src/components/careers/desktop/CurrentOpeningsSection.tsx
+++ b/src/components/careers/desktop/CurrentOpeningsSection.tsx
@@ -6,6 +6,7 @@ import {CurrentOpeningAccordion} from "./CurrentOpeningAccordion";
 import {Opening, Openings} from "../../../constants/openings";
 import {borderStyles, borderStyle} from "../../../theme/styles";
 
+
 const StyledGrid = styled(Grid)({
   width: '100%',
   height: '63.75vw',

--- a/src/components/careers/desktop/CurrentOpeningsSection.tsx
+++ b/src/components/careers/desktop/CurrentOpeningsSection.tsx
@@ -3,7 +3,7 @@ import {Grid, makeStyles, styled, Typography} from '@material-ui/core'
 import {CloseButton} from "../../about/desktop/CloseButton";
 import {theme} from "../../../theme";
 import {CurrentOpeningAccordion} from "./CurrentOpeningAccordion";
-import {Openings} from "../../../constants/openings";
+import {Opening, Openings} from "../../../constants/openings";
 import {borderStyles, borderStyle} from "../../../theme/styles";
 
 const StyledGrid = styled(Grid)({
@@ -14,6 +14,8 @@ const StyledGrid = styled(Grid)({
 });
 
 const StyledText = styled(Typography)({
+  marginTop: '4.5vw',
+  marginBottom: '3.375vw',
   fontFamily: theme.typography.fontFamily,
   fontSize: '2.625vw',
   fontWeight: 600,
@@ -27,6 +29,7 @@ const StyledText = styled(Typography)({
 
 const useStyleClasses = makeStyles({
   buttonStyle: {
+    marginTop: '2.75vw',
     transition: '0.25s',
     backgroundColor: theme.palette.secondary.main,
     border: 'initial',
@@ -70,7 +73,14 @@ export const CurrentOpeningsSection: React.FC<Props> = (props: Props) => {
         <StyledText>{props.titleText}</StyledText>
       </Grid>
       <Grid item className={borders.leftBorder + ' ' + borders.topBorder + ' ' + borders.rightBorder} style={{width: '61.25vw'}}>
-        <CurrentOpeningAccordion opening={props.openings.designer} expanded={expanded==='panel1'} onChange={handleChange('panel1')}  border={borderStyle}/>
+        {Object.values(props.openings).map((opening: Opening, i: number) => (
+          <CurrentOpeningAccordion
+            key={opening.id}
+            opening={opening}
+            expanded={expanded===opening.id}
+            onChange={handleChange(opening.id)}
+            border={borderStyle} />
+        ))}
       </Grid>
       <Grid item>
         <CloseButton classes={styleClasses.buttonStyle} text={props.buttonText} handleClick={props.onButtonClick} />

--- a/src/components/careers/desktop/CurrentOpeningsSection.tsx
+++ b/src/components/careers/desktop/CurrentOpeningsSection.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import {Grid, makeStyles, styled, Typography} from '@material-ui/core'
+import {CloseButton} from "../../about/desktop/CloseButton";
+import {theme} from "../../../theme";
+import {CurrentOpeningAccordion} from "./CurrentOpeningAccordion";
+import {Openings} from "../../../constants/openings";
+import {borderStyles, borderStyle} from "../../../theme/styles";
+
+const StyledGrid = styled(Grid)({
+  width: '100%',
+  height: '63.75vw',
+  boxSizing: 'border-box',
+  backgroundColor: 'rgba(0, 0, 0, 0.15)',
+});
+
+const StyledText = styled(Typography)({
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '2.625vw',
+  fontWeight: 600,
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1,
+  letterSpacing: '-1.26px',
+  textAlign: "center",
+  color: theme.palette.text.primary
+});
+
+const useStyleClasses = makeStyles({
+  buttonStyle: {
+    transition: '0.25s',
+    backgroundColor: theme.palette.secondary.main,
+    border: 'initial',
+    '&:hover': {
+      border: 'initial',
+      boxShadow: '0 0.5vw 0.5vw -0.2vw rgba(255, 255, 255, 1)',
+      transform: 'translateY(-0.25vw)',
+    },
+    '&:focus': {
+      border: 'initial',
+      boxShadow: '0 0.5vw 0.5vw -0.2vw rgba(255, 255, 255, 1)',
+      transform: 'translateY(-0.25vw)',
+    }
+  }
+});
+
+const useBorders = makeStyles(borderStyles);
+
+interface Props {
+  titleText: string;
+  buttonText: string;
+  onButtonClick: () => void;
+  openings: Openings;
+  classes?: string;
+}
+
+export const CurrentOpeningsSection: React.FC<Props> = (props: Props) => {
+
+  const borders = useBorders();
+  const styleClasses = useStyleClasses();
+
+  const [expanded, setExpanded] = React.useState<string | false>(false);
+  // eslint-disable-next-line
+  const handleChange = (panel: string) => (event: React.ChangeEvent<{}>, isExpanded: boolean) => {
+    setExpanded(isExpanded ? panel : false);
+  };
+
+  return (
+    <StyledGrid className={props.classes} container direction='column' justify={'flex-start'} alignItems={'center'}>
+      <Grid item>
+        <StyledText>{props.titleText}</StyledText>
+      </Grid>
+      <Grid item className={borders.leftBorder + ' ' + borders.topBorder + ' ' + borders.rightBorder} style={{width: '61.25vw'}}>
+        <CurrentOpeningAccordion opening={props.openings.designer} expanded={expanded==='panel1'} onChange={handleChange('panel1')}  border={borderStyle}/>
+      </Grid>
+      <Grid item>
+        <CloseButton classes={styleClasses.buttonStyle} text={props.buttonText} handleClick={props.onButtonClick} />
+      </Grid>
+    </StyledGrid>
+  );
+}

--- a/src/components/careers/desktop/MeetBuildersTitleBox.tsx
+++ b/src/components/careers/desktop/MeetBuildersTitleBox.tsx
@@ -12,7 +12,7 @@ const StyledGrid = styled(Grid)({
   position: 'relative'
 });
 
-const StyledTextPrimary = styled(Typography)({
+const StyledText = styled(Typography)({
   fontFamily: theme.typography.fontFamily,
   fontSize: '2.625vw',
   fontWeight: 600,
@@ -33,7 +33,7 @@ export const MeetBuildersTitleBox: React.FC<Props> = (props: Props) => {
   return (
     <StyledGrid className={props.classes} container direction={'column'} spacing={0} justify={'flex-start'} alignItems={'center'}>
       <Grid item>
-        <StyledTextPrimary>{props.text}</StyledTextPrimary>
+        <StyledText>{props.text}</StyledText>
       </Grid>
     </StyledGrid>
   );

--- a/src/constants/openings.ts
+++ b/src/constants/openings.ts
@@ -1,0 +1,39 @@
+export enum Role {
+  design,
+  frontend,
+  backend
+}
+
+export interface Opening {
+  role: Role;
+  title: string;
+  location: string;
+  description: string;
+}
+
+export interface Openings {
+  frontEndDeveloper: Readonly<Opening>;
+  solidityDeveloper: Readonly<Opening>;
+  designer: Readonly<Opening>;
+}
+
+export const openings: Openings = {
+  frontEndDeveloper: {
+    role: Role.frontend,
+    title: 'Full Stack Engineer',
+    location: 'Victoria - Vancouver - Remote (+/- 3 hrs PST)',
+    description: 'MetaLab is primarily PST-based so the candidate applying for this role must be comfortable with ~2hrs overlap during their workday (often 4-6:30pm GMT), operating autonomously in the other hours. We have a small (and growing!) team in Europe — plus global clients — so we resource teams in the same time zone together when. We have a small (and growing!) team in Europe — plus global crole must be comfortable with ~2hrs overlap during their workday (often 4-6:30pm GMT), operating autonomously in the other hours. '
+  },
+  solidityDeveloper: {
+    role: Role.backend,
+    title: 'Solidity Developer',
+    location: 'Remote (GMT +0 Time Zone)',
+    description: 'MetaLab is primarily PST-based so the candidate applying for this role must be comfortable with ~2hrs overlap during their workday (often 4-6:30pm GMT), operating autonomously in the other hours. We have a small (and growing!) team in Europe — plus global clients — so we resource teams in the same time zone together when. We have a small (and growing!) team in Europe — plus global crole must be comfortable with ~2hrs overlap during their workday (often 4-6:30pm GMT), operating autonomously in the other hours. '
+  },
+  designer: {
+    role: Role.design,
+    title: 'Product Designer',
+    location: 'Remote / Vancouver / Victoria',
+    description: 'MetaLab is primarily PST-based so the candidate applying for this role must be comfortable with ~2hrs overlap during their workday (often 4-6:30pm GMT), operating autonomously in the other hours. We have a small (and growing!) team in Europe — plus global clients — so we resource teams in the same time zone together when. We have a small (and growing!) team in Europe — plus global crole must be comfortable with ~2hrs overlap during their workday (often 4-6:30pm GMT), operating autonomously in the other hours. '
+  },
+}

--- a/src/constants/openings.ts
+++ b/src/constants/openings.ts
@@ -5,6 +5,7 @@ export enum Role {
 }
 
 export interface Opening {
+  id: string;
   role: Role;
   title: string;
   location: string;
@@ -19,18 +20,21 @@ export interface Openings {
 
 export const openings: Openings = {
   frontEndDeveloper: {
+    id: '1',
     role: Role.frontend,
     title: 'Full Stack Engineer',
     location: 'Victoria - Vancouver - Remote (+/- 3 hrs PST)',
     description: 'MetaLab is primarily PST-based so the candidate applying for this role must be comfortable with ~2hrs overlap during their workday (often 4-6:30pm GMT), operating autonomously in the other hours. We have a small (and growing!) team in Europe — plus global clients — so we resource teams in the same time zone together when. We have a small (and growing!) team in Europe — plus global crole must be comfortable with ~2hrs overlap during their workday (often 4-6:30pm GMT), operating autonomously in the other hours. '
   },
   solidityDeveloper: {
+    id: '2',
     role: Role.backend,
     title: 'Solidity Developer',
     location: 'Remote (GMT +0 Time Zone)',
     description: 'MetaLab is primarily PST-based so the candidate applying for this role must be comfortable with ~2hrs overlap during their workday (often 4-6:30pm GMT), operating autonomously in the other hours. We have a small (and growing!) team in Europe — plus global clients — so we resource teams in the same time zone together when. We have a small (and growing!) team in Europe — plus global crole must be comfortable with ~2hrs overlap during their workday (often 4-6:30pm GMT), operating autonomously in the other hours. '
   },
   designer: {
+    id: '3',
     role: Role.design,
     title: 'Product Designer',
     location: 'Remote / Vancouver / Victoria',

--- a/src/pages/Careers.tsx
+++ b/src/pages/Careers.tsx
@@ -13,6 +13,8 @@ import {MeetBuildersTitleBox} from "../components/careers/desktop/MeetBuildersTi
 import {ProfileWheel} from "../components/careers/desktop/ProfileWheel";
 import {testimonials} from "../constants/testimonials";
 import {TestimonialSection} from "../components/careers/desktop/TestimonialSection";
+import {CurrentOpeningsSection} from "../components/careers/desktop/CurrentOpeningsSection";
+import {openings} from "../constants/openings";
 
 const Root = styled(Grid)({
   margins: 'auto',
@@ -78,6 +80,9 @@ export const Careers: React.FC = () => {
         </Grid>
         <Grid item xs={12}>
           <TestimonialSection testimonials={testimonials} />
+        </Grid>
+        <Grid item xs={12}>
+          <CurrentOpeningsSection openings={openings} titleText={'Current Openings'} buttonText={'APPLY NOW'} onButtonClick={navigationToActivation} />
         </Grid>
       </ContentContainer>
       <RightMargin xs={1} border={borderStyle} height='116.775vw' longAccentIndex={3}/>


### PR DESCRIPTION
Added desktop Careers page Current Openings section and openings constants. Closes #70.

Job openings can be added, removed, or edited by changing the openings constants. We may want those constants to be pulled from airtable in the future so they are easier to change.