### PR TITLE
Add initial mobile home page

### DIFF
--- a/src/components/CookieConsentPrompt.tsx
+++ b/src/components/CookieConsentPrompt.tsx
@@ -56,18 +56,7 @@ const useButtonWrapperStyle = makeStyles({
   buttonWrapperMobile: {
     position: 'relative',
     left: '32vw',
-    bottom: '2vw',
-    transition: '0.15s',
-    '&:hover': {
-      border: 'initial',
-      boxShadow: '0 1.9vw 1.9vw -0.75vw rgba(255, 255, 255, 1)',
-      transform: 'translateY(-0.1vw)',
-    },
-    '&:focus': {
-      border: 'initial',
-      boxShadow: '0 1.9vw 1.9vw -0.75vw rgba(255, 255, 255, 1)',
-      transform: 'translateY(-0.1vw)',
-    }
+    bottom: '2vw'
   }
 });
 

--- a/src/components/CookieConsentPrompt.tsx
+++ b/src/components/CookieConsentPrompt.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import CookieConsent from "react-cookie-consent";
 import {theme} from "../theme";
-import {makeStyles} from "@material-ui/core";
+import {makeStyles, Theme, useMediaQuery, useTheme} from "@material-ui/core";
 
 
 const cookieStyle = {
@@ -10,7 +10,7 @@ const cookieStyle = {
 
 const cookieButtonStyle = {
   margin: 0,
-  width: '9vw',
+  width: '9.5vw',
   padding: '0.75vw',
   background: theme.palette.secondary.main,
   fontFamily: theme.typography.fontFamily,
@@ -52,8 +52,54 @@ const useButtonWrapperStyle = makeStyles({
       boxShadow: '0 0.5vw 0.5vw -0.2vw rgba(255, 255, 255, 1)',
       transform: 'translateY(-0.1vw)',
     }
+  },
+  buttonWrapperMobile: {
+    position: 'relative',
+    left: '32vw',
+    bottom: '2vw',
+    transition: '0.15s',
+    '&:hover': {
+      border: 'initial',
+      boxShadow: '0 1.9vw 1.9vw -0.75vw rgba(255, 255, 255, 1)',
+      transform: 'translateY(-0.1vw)',
+    },
+    '&:focus': {
+      border: 'initial',
+      boxShadow: '0 1.9vw 1.9vw -0.75vw rgba(255, 255, 255, 1)',
+      transform: 'translateY(-0.1vw)',
+    }
   }
 });
+
+
+const cookieButtonStyleMobile = {
+  margin: 0,
+  width: '36vw',
+  padding: '2.85vw',
+  background: theme.palette.secondary.main,
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '3vw',
+  fontWeight: 'bold',
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1,
+  letterSpacing: '1.5px',
+  textAlign: "center",
+  color: theme.palette.text.primary,
+}
+
+const cookieContentStyleMobile = {
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '3vw',
+  fontWeight: 'normal',
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1,
+  letterSpacing: 'normal',
+  textAlign: "center",
+  color: theme.palette.text.secondary,
+}
+
 
 interface Props {
   prompt: string;
@@ -63,15 +109,30 @@ interface Props {
 export const CookieConsentPrompt: React.FC<Props> = (props: Props) => {
 
   const buttonWrapperStyle = useButtonWrapperStyle();
+  const theme: Theme = useTheme();
+  const desktop = useMediaQuery(theme.breakpoints.up('lg'));
 
-  return (
-    <CookieConsent
-      debug={props.debug}
-      style={cookieStyle}
-      buttonStyle={cookieButtonStyle}
-      buttonWrapperClasses={buttonWrapperStyle.buttonWrapper}
-      contentStyle={cookieContentStyle}>
-      {props.prompt}
-    </CookieConsent>
-  );
+  if (desktop) {
+    return (
+      <CookieConsent
+        debug={props.debug}
+        style={cookieStyle}
+        buttonStyle={cookieButtonStyle}
+        buttonWrapperClasses={buttonWrapperStyle.buttonWrapper}
+        contentStyle={cookieContentStyle}>
+        {props.prompt}
+      </CookieConsent>
+    );
+  } else {
+    return (
+      <CookieConsent
+        debug={props.debug}
+        style={cookieStyle}
+        buttonStyle={cookieButtonStyleMobile}
+        buttonWrapperClasses={buttonWrapperStyle.buttonWrapperMobile}
+        contentStyle={cookieContentStyleMobile}>
+        {props.prompt}
+      </CookieConsent>
+    );
+  }
 }

--- a/src/components/FooterMobile.tsx
+++ b/src/components/FooterMobile.tsx
@@ -70,7 +70,8 @@ export const FooterMobile: React.FC = () => {
   return (
     <FooterContainer container justify='flex-start'>
       <FooterMargin item className={borders.topBorder} />
-      <FooterBody container item spacing={0} direction='row' justify="space-between" alignItems='center' className={`${borders.topBorder} ${borders.leftBorder}`}>
+      <FooterBody container item spacing={0} direction='row' justify="space-between" alignItems='center'
+        className={`${borders.topBorder} ${borders.leftBorder} ${borders.rightBorder}`}>
         <Grid item xs={7}>
           <CopyrightText>{COPYRIGHT_TEXT}</CopyrightText>
         </Grid>
@@ -97,7 +98,7 @@ export const FooterMobile: React.FC = () => {
           </Grid>
         </Grid>
       </FooterBody>
-      <FooterMargin item className={`${borders.topBorder} ${borders.leftBorder}`} />
+      <FooterMargin item className={borders.topBorder} />
     </FooterContainer>
   );
 }

--- a/src/components/HeaderMobile.tsx
+++ b/src/components/HeaderMobile.tsx
@@ -48,7 +48,8 @@ export const HeaderMobile: React.FC = () => {
     <StyledAppBar position="static">
       <Grid container spacing={0} direction='row' justify="flex-start" alignItems='flex-start' style={{height: 'inherit'}}>
         <HeaderMargin item className={borders.bottomBorder} />
-        <LogoContainer container item spacing={0} direction='row' justify="space-between" alignItems='center' className={borders.bottomLeftBorder}>
+        <LogoContainer container item spacing={0} direction='row' justify="space-between" alignItems='center'
+          className={`${borders.bottomLeftBorder} ${borders.rightBorder}`}>
           <Grid item>
             <StyledLogo src={LOGO_PATH} alt="dOrg Logo" onClick={onLogoClick} />
           </Grid>
@@ -56,7 +57,7 @@ export const HeaderMobile: React.FC = () => {
             <MobileMenu />
           </Grid>
         </LogoContainer>
-        <HeaderMargin item className={borders.bottomLeftBorder} />
+        <HeaderMargin item className={borders.bottomBorder} />
       </Grid>
     </StyledAppBar>
   );

--- a/src/components/RightMargin.tsx
+++ b/src/components/RightMargin.tsx
@@ -75,7 +75,7 @@ const RightMargin: React.FC<Props> = (props: Props) => {
   const desktop = useMediaQuery(theme.breakpoints.up('lg'));
 
   return (
-    <StyledGrid item xs={props.xs} style={{borderLeft: props.border, height: props.height, width: desktop ? '7.5vw' : '5vw'}}>
+    <StyledGrid item xs={props.xs} style={{borderLeft: desktop ? props.border : '', height: props.height, width: desktop ? '7.5vw' : '5vw'}}>
       {desktop ?
         <Accents border={props.centerLineHeight ? props.border : ''}
           longAccentIndex={props.longAccentIndex}

--- a/src/components/careers/mobile/openings_section/CurrentOpeningSectionMobile.tsx
+++ b/src/components/careers/mobile/openings_section/CurrentOpeningSectionMobile.tsx
@@ -9,7 +9,7 @@ import {CloseButtonMobile} from "../../../about/mobile/CloseButtonMobile";
 
 const StyledGrid = styled(Grid)({
   width: '100%',
-  height: '285vw',
+  minHeight: '205vw',
   boxSizing: 'border-box',
   backgroundColor: 'rgba(0, 0, 0, 0.15)',
 });
@@ -31,6 +31,7 @@ const StyledText = styled(Typography)({
 const useStyleClasses = makeStyles({
   buttonStyle: {
     marginTop: '7.5vw',
+    marginBottom: '11vw',
     width: '81vw',
     transition: '0.25s',
     backgroundColor: theme.palette.secondary.main,

--- a/src/components/home/mobile/BulletsBoxMobile.tsx
+++ b/src/components/home/mobile/BulletsBoxMobile.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import {styled, Typography, Grid} from '@material-ui/core'
+import {theme} from "../../../theme";
+
+
+const StyledGrid = styled(Grid)({
+  width: '100%',
+  background: 'transparent',
+  boxSizing: 'border-box'
+});
+
+const ListItem = styled(Grid)({
+  width: '82vw',
+  marginBottom: '6vw'
+});
+
+const StyleIcon = styled('img')({
+  width: "3.55vw",
+  height: "3.55vw",
+  marginRight: '4vw',
+  objectFit: "contain",
+  float: 'left'
+});
+
+const BulletText = styled(Typography)({
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '3.1vw',
+  fontWeight: 500,
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1,
+  letterSpacing: 'normal',
+  textAlign: "left",
+  color: theme.palette.text.primary
+});
+
+interface Props {
+  bullets: string[];
+  classes?: string;
+}
+
+export const BulletsBoxMobile: React.FC<Props> = (props: Props) => {
+
+  return (
+    <StyledGrid className={props.classes} container spacing={0} direction='column' justify='flex-start' alignItems='flex-start'>
+      {props.bullets.map((bullet: string, i: number) => (
+        <ListItem item key={`bullet-${i}`}>
+          <StyleIcon src={'imgs/check-circle.svg'} alt='circled check mark icon' />
+          <BulletText>{bullet}</BulletText>
+        </ListItem>
+      ))}
+    </StyledGrid>
+  );
+}

--- a/src/components/home/mobile/ClientContainerMobile.tsx
+++ b/src/components/home/mobile/ClientContainerMobile.tsx
@@ -1,0 +1,49 @@
+import {Grid, styled} from "@material-ui/core";
+import React from "react";
+import {Companies} from "../../../constants/companies";
+import {Communities} from "../../../constants/communities";
+import {Client} from "../../../constants/clients";
+import {ClientItemMobile} from "./ClientItemMobile";
+
+const StyledGrid = styled(Grid)({
+  width: '100%',
+  minHeight: '172vw',
+  position: 'relative',
+  zIndex: 1
+});
+
+const StyledRings = styled('img')({
+  width: '68.75vw',
+  height: '69.55vw',
+  objectFit: 'contain',
+  position: 'absolute',
+  transform: 'scaleY(-1)',
+  bottom: '-0.4vw',
+  right: '0.1vw',
+  zIndex: 0
+});
+
+interface Props {
+  clients: Companies | Communities;
+  classes?: string;
+}
+
+export const ClientContainerMobile: React.FC<Props> = (props: Props) => {
+
+  const [expanded, setExpanded] = React.useState<string | false>(false);
+  // eslint-disable-next-line
+  const handleChange = (panel: string) => (event: React.ChangeEvent<{}>, isExpanded: boolean) => {
+    setExpanded(isExpanded ? panel : false);
+  };
+
+  return (
+    <StyledGrid className={props.classes} container spacing={0} direction='column' justify='flex-start' alignItems='flex-start'>
+      {Object.values(props.clients).map((client: Client) => (
+        <Grid item key={`${client.name}`} style={{width: '100%'}}>
+          <ClientItemMobile client={client} expanded={expanded===client.name} someExpanded={expanded as boolean} onChange={handleChange(client.name)}/>
+        </Grid>
+      ))}
+      {!expanded && <StyledRings src='imgs/concentric-rings-left.svg' alt={'concentric rings flourish'} />}
+    </StyledGrid>
+  );
+}

--- a/src/components/home/mobile/ClientContainerMobile.tsx
+++ b/src/components/home/mobile/ClientContainerMobile.tsx
@@ -7,7 +7,7 @@ import {ClientItemMobile} from "./ClientItemMobile";
 
 const StyledGrid = styled(Grid)({
   width: '100%',
-  minHeight: '172vw',
+  minHeight: '160vw',
   position: 'relative',
   zIndex: 1
 });

--- a/src/components/home/mobile/ClientItemMobile.tsx
+++ b/src/components/home/mobile/ClientItemMobile.tsx
@@ -83,7 +83,7 @@ export const ClientItemMobile: React.FC<Props> = (props: Props) => {
   })();
 
   return (
-    <Accordion classes={accordionStyle} className={classes} square elevation={0} style={{margin: 0, padding: 0, maxWidth: '89.9vw'}}
+    <Accordion classes={accordionStyle} className={classes} square elevation={0} style={{margin: 0, padding: 0, maxWidth: '89.73vw'}}
       expanded={props.expanded} onChange={props.onChange} >
       <AccordionSummary aria-controls={`${props.client.name}-content`} id={`${props.client.name}-header`}
         style={{margin: 0, padding: 0}}>

--- a/src/components/home/mobile/ClientItemMobile.tsx
+++ b/src/components/home/mobile/ClientItemMobile.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import {Accordion, AccordionDetails, AccordionSummary, Grid, makeStyles, styled, Typography} from '@material-ui/core'
+import {Client} from "../../../constants/clients";
+import {theme} from "../../../theme";
+import {ExpandedContentBoxMobile} from "./ExpandedContentBoxMobile";
+
+
+const StyledGrid = styled(Grid)({
+  width: '100%',
+  height: '7.6vw',
+  paddingLeft: '4.75vw',
+  boxSizing: 'border-box',
+  backgroundColor: 'transparent',
+  position: 'relative'
+});
+
+const StyledTitle = styled(Typography)({
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '6.67vw',
+  fontWeight: 500,
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1,
+  letterSpacing: 'normal',
+  textAlign: "left",
+  color: theme.palette.text.primary,
+});
+
+const ClientIcon = styled('img')({
+  marginRight:'5.25vw',
+  width: "5.7vw",
+  height: "5.7vw",
+  objectFit: "contain",
+});
+
+const SelectedIcon = styled('img')({
+  marginLeft: '24vw',
+  width: "4.75vw",
+  height: "4.75vw",
+  objectFit: "contain",
+  filter: 'brightness(0) saturate(100%) invert(100%)'
+});
+
+const ShadowOverlay = styled('div')({
+  width: '100vw',
+  height: '19.5vw',
+  backgroundColor: 'rgba(0, 0, 0, 0.1)',
+  position: 'absolute',
+  top: 0
+});
+
+interface Props {
+  client: Client;
+  expanded: boolean;
+  someExpanded: boolean;
+  onChange: (event: React.ChangeEvent<{}>, isExpanded: boolean) => void; //eslint-disable-line
+  classes?: string;
+}
+
+export const ClientItemMobile: React.FC<Props> = (props: Props) => {
+
+  const classes: string = props.classes ? props.classes : '';
+
+  const accordionStyle = makeStyles({
+    root: {
+      margin: 0,
+      width: 'inherit',
+      background: theme.palette.primary.main
+    },
+    expanded: {
+      backgroundColor: props.client.highlightColor
+    }
+  })();
+
+  const selectStyles = makeStyles({
+    hidden: {
+      opacity: props.someExpanded && !props.expanded ? 0.3 : 1
+    },
+    selected: {
+      height: props.expanded ? '9.75vw' : '7.6vw',
+      backgroundColor: props.expanded ? props.client.highlightColor : theme.palette.primary.main
+    }
+  })();
+
+  return (
+    <Accordion classes={accordionStyle} className={classes} square elevation={0} style={{margin: 0, padding: 0, maxWidth: '89.9vw'}}
+      expanded={props.expanded} onChange={props.onChange} >
+      <AccordionSummary aria-controls={`${props.client.name}-content`} id={`${props.client.name}-header`}
+        style={{margin: 0, padding: 0}}>
+        <StyledGrid container direction='row' justify={'flex-start'} alignItems={'center'} className={classes + ' ' + selectStyles.selected}>
+          <Grid item>
+            <ClientIcon src={props.client.icon} alt='client icon' className={selectStyles.hidden}/>
+          </Grid>
+          <Grid item>
+            <StyledTitle className={selectStyles.hidden}>{props.client.name}</StyledTitle>
+          </Grid>
+          <Grid item>
+            {props.expanded && <SelectedIcon src={'imgs/external-link-icon.svg'} alt='pop-up content icon' />}
+          </Grid>
+        </StyledGrid>
+        {props.expanded && <ShadowOverlay />}
+      </AccordionSummary>
+      <AccordionDetails style={{margin: 0, padding: 0}}>
+        <ExpandedContentBoxMobile title={props.client.name} project={props.client.project} />
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/src/components/home/mobile/ClientTabsMobile.tsx
+++ b/src/components/home/mobile/ClientTabsMobile.tsx
@@ -1,0 +1,97 @@
+import {makeStyles, styled, Tab, Tabs} from "@material-ui/core";
+import React from "react";
+import {Companies} from "../../../constants/companies";
+import {Communities} from "../../../constants/communities";
+import {theme} from "../../../theme";
+import {borderStyle} from "../../../theme/styles";
+import {ClientContainerMobile} from "./ClientContainerMobile";
+
+
+const StyledContainer = styled('div')({
+  width: '100%',
+  position: 'relative',
+  zIndex: 1
+});
+
+const useTabStyle = makeStyles({
+  root: {
+    width: '45vw',
+    height: '16.25vw',
+    borderBottom: borderStyle,
+    borderTop: 'none',
+    borderRight: 'none',
+    borderRadius: 0,
+    fontFamily: theme.typography.fontFamily,
+    fontSize: '3.333vw',
+    fontWeight: 'bold',
+    fontStretch: "normal",
+    fontStyle: "normal",
+    lineHeight: 1,
+    letterSpacing: '1.4px',
+    textAlign: "left",
+    color: 'rgba(255, 255, 255, 0.5)',
+    opacity: 1
+  },
+  selected: {
+    color: theme.palette.text.secondary
+  }
+});
+
+const useTabContainerStyle = makeStyles({
+  root: {
+    width: '100%'
+  },
+  indicator: {
+    width: '45vw',
+    height: '0.716vw'
+  }
+})
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index } = props;
+  return (
+    <div role="tabpanel" hidden={value !== index} id={`tabpanel-${index}`} aria-labelledby={`tab-${index}`}>
+      {value === index && (children)}
+    </div>
+  );
+}
+
+interface Props {
+  companiesTitle: string;
+  communitiesTitle: string;
+  companies: Companies;
+  communities: Communities;
+  classes?: string;
+}
+
+export const ClientTabsMobile: React.FC<Props> = (props: Props) => {
+
+  const tabStyle = useTabStyle();
+  const tabContainerStyle = useTabContainerStyle();
+
+  const [value, setValue] = React.useState(0);
+  const handleChange = (event: React.ChangeEvent<unknown>, newValue: number) => {
+    setValue(newValue);
+  };
+
+  return (
+    <StyledContainer className={props.classes}>
+      <Tabs value={value} onChange={handleChange} aria-label="Companies and Communities" classes={tabContainerStyle}>
+        <Tab label={props.companiesTitle} id={`tab-${0}`} aria-controls={`tabpanel-${0}`} classes={tabStyle}/>
+        <Tab label={props.communitiesTitle} id={`tab-${1}`} aria-controls={`tabpanel-${1}`} classes={tabStyle}/>
+      </Tabs>
+      <TabPanel value={value} index={0}>
+        <ClientContainerMobile clients={props.companies} />
+      </TabPanel>
+      <TabPanel value={value} index={1}>
+        <ClientContainerMobile clients={props.communities} />
+      </TabPanel>
+    </StyledContainer>
+  );
+}

--- a/src/components/home/mobile/ExpandedContentBoxMobile.tsx
+++ b/src/components/home/mobile/ExpandedContentBoxMobile.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import {styled, Typography, Grid, makeStyles} from '@material-ui/core'
+import {Project} from "../../../constants/clients";
+import {theme} from "../../../theme";
+import {ChipLargeMobile} from "../../careers/mobile/profile_popup/ChipLargeMobile";
+import {BulletsBoxMobile} from "./BulletsBoxMobile";
+
+const StyledGrid = styled(Grid)({
+  height: 'max-content',
+  width: '100%',
+  padding: '8.5vw 4vw 4vw 4vw',
+  position: 'relative'
+});
+
+const StyledDescription = styled(Typography)({
+  marginBottom: '9.6vw',
+  maxWidth: '81.25vw',
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '3.57vw',
+  fontWeight: 'normal',
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1.6,
+  letterSpacing: '-0.45px',
+  textAlign: "left",
+  color: theme.palette.text.primary,
+  zIndex: 1,
+});
+
+const BulletsContainer = styled(Grid)({
+  marginBottom: '4.7vw',
+  background: 'transparent',
+  boxSizing: 'border-box',
+  zIndex: 1,
+});
+
+
+const ChipContainer = styled(Grid)({
+  background: 'transparent',
+  boxSizing: 'border-box',
+  zIndex: 1,
+});
+
+const useChipStyle = makeStyles({
+  chip: {
+    marginRight: '2.4vw',
+    backgroundColor: 'rgba(0, 0, 0, 0.2)'
+  }
+});
+
+const IllustrationView = styled('div')({
+  position: 'relative',
+  zIndex: 0
+})
+
+interface Props {
+  title: string;
+  project: Project;
+  classes?: string;
+}
+
+export const ExpandedContentBoxMobile: React.FC<Props> = (props: Props) => {
+
+  const chipStyle = useChipStyle();
+
+  return (
+    <StyledGrid className={props.classes} container spacing={0} direction='column' justify='flex-start' alignItems='flex-start'>
+      <Grid item>
+        <StyledDescription>{props.project.description}</StyledDescription>
+      </Grid>
+      {props.project.bullets.length > 0 &&
+      <BulletsContainer item>
+        <BulletsBoxMobile bullets={props.project.bullets } />
+      </BulletsContainer>}
+      <ChipContainer item container spacing={0} direction='row' justify='flex-start' alignItems='flex-start'>
+        {props.project.technologies.map((technology: string, i: number) => (
+          <Grid item key={`technology-${i}`}>
+            <ChipLargeMobile classes={chipStyle.chip} text={technology} />
+          </Grid>
+        ))}
+      </ChipContainer>
+      <IllustrationView style={props.project?.illustration?.position}>
+        {props.project?.illustration?.view}
+      </IllustrationView>
+    </StyledGrid>
+  );
+}

--- a/src/components/home/mobile/HomeTItleBoxMobile.tsx
+++ b/src/components/home/mobile/HomeTItleBoxMobile.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import {Grid, styled, Typography,} from '@material-ui/core'
+import { theme } from "../../../theme";
+
+
+const StyledGrid = styled(Grid)({
+  width: '100%',
+  height: '45.25vw',
+  padding: '6.4vw 3.6vw',
+  boxSizing: 'border-box',
+  background: theme.palette.primary.main
+});
+
+const TitleTextPrimary = styled(Typography)({
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '6.67vw',
+  fontWeight: 'bold',
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1,
+  letterSpacing: '-0.84px',
+  textAlign: "left",
+  color: theme.palette.text.primary
+});
+
+const TitleTextSecondary = styled(Typography)({
+  marginTop: '0.967vw',
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '6.67vw',
+  fontWeight: 'bold',
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1,
+  letterSpacing: '-0.84px',
+  textAlign: "left",
+  color: theme.palette.text.secondary
+});
+
+const SubtitleText = styled(Typography)({
+  marginTop: '3.6vw',
+  fontFamily: theme.typography.fontFamily,
+  fontSize: '3.33vw',
+  fontWeight: 'bold',
+  fontStretch: "normal",
+  fontStyle: "normal",
+  lineHeight: 1.71,
+  letterSpacing: 'normal',
+  textAlign: "left",
+  color: theme.palette.text.primary
+});
+
+interface Props {
+  titleTextPrimary: string;
+  titleTextSecondary: string;
+  subTitleText: string;
+  classes?: string;
+}
+
+export const HomeTitleBoxMobile: React.FC<Props> = (props: Props) => {
+  return (
+    <StyledGrid className={props.classes} container direction={'column'} spacing={0} justify={'flex-start'} alignItems={'flex-start'}>
+      <Grid item>
+        <TitleTextPrimary>{props.titleTextPrimary}</TitleTextPrimary>
+      </Grid>
+      <Grid item>
+        <TitleTextSecondary>{props.titleTextSecondary}</TitleTextSecondary>
+      </Grid>
+      <Grid item>
+        <SubtitleText>{props.subTitleText}</SubtitleText>
+      </Grid>
+    </StyledGrid>
+  );
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -98,7 +98,8 @@ export const About: React.FC = () => {
     return (
       <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
         <LeftMargin border={borderStyle} height='550vw' centerLineHeight='180.5vw' />
-        <ContentContainer container item spacing={0} direction='row' justify="center" alignItems='flex-start' style={{width: '90vw'}}>
+        <ContentContainer container item spacing={0} direction='row' justify="center" alignItems='flex-start' style={{width: '90vw'}}
+          className={borders.rightBorder}>
           <Grid item xs={12}>
             <AboutTitleBoxMobile text={ABOUT_TITLE} classes={borders.bottomLeftBorder} />
             <PressBoxMobile press={press} classes={borders.bottomLeftBorder} />

--- a/src/pages/Careers.tsx
+++ b/src/pages/Careers.tsx
@@ -99,8 +99,9 @@ export const Careers: React.FC = () => {
   } else {
     return (
       <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
-        <LeftMargin border={borderStyle} height='884.5vw'/>
-        <ContentContainer container item spacing={0} direction='row' justify="center" alignItems='flex-start' style={{width: '90vw'}}>
+        <LeftMargin border={borderStyle} height='804.5vw'/>
+        <ContentContainer container item spacing={0} direction='row' justify="center" alignItems='flex-start' style={{width: '90vw'}}
+          className={borders.rightBorder}>
           <Grid item xs={12}>
             <CareersTitleBoxMobile textPrimaryL1={'Discover a new'} textPrimaryL2={'way to'} textSecondary={'work'}
               classes={borders.bottomLeftBorder}/>
@@ -135,7 +136,7 @@ export const Careers: React.FC = () => {
               classes={borders.leftBorder}/>
           </Grid>
         </ContentContainer>
-        <RightMargin border={borderStyle} height='884.5vw' longAccentIndex={3}/>
+        <RightMargin border={borderStyle} height='804.5vw' longAccentIndex={3}/>
       </Root>
     );
   }

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -54,7 +54,8 @@ export const Contact: React.FC = () => {
     return (
       <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
         <LeftMargin border={borderStyle} height='203.75vw'/>
-        <ContentContainer container item spacing={0} direction='row' justify="center" alignItems='flex-start' style={{width: '90vw'}}>
+        <ContentContainer container item spacing={0} direction='row' justify="center" alignItems='flex-start' style={{width: '90vw'}}
+          className={borders.rightBorder}>
           <Grid item xs={12}>
             <ContactTitleBoxMobile title={TITLE} subtitle={SUBTITLE} instructions={INSTRUCTIONS} classes={borders.bottomLeftBorder}/>
           </Grid>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -87,8 +87,9 @@ export const Home: React.FC = () => {
   } else {
     return (
       <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
-        <LeftMargin border={borderStyle} height='233.45vw' />
-        <ContentContainer container item spacing={0} direction='row' justify="center" alignItems='flex-start' style={{width: '90vw'}}>
+        <LeftMargin border={borderStyle} height='221.45vw' />
+        <ContentContainer container item spacing={0} direction='row' justify="center" alignItems='flex-start' style={{width: '90vw'}}
+          className={borders.rightBorder}>
           <HomeTitleBoxMobile
             titleTextPrimary={'We build custom'}
             titleTextSecondary={'Dapps'}
@@ -101,7 +102,7 @@ export const Home: React.FC = () => {
             communities={communities}
             classes={borders.leftBorder}/>
         </ContentContainer>
-        <RightMargin border={borderStyle} height={'233.45vw'} />
+        <RightMargin border={borderStyle} height={'221.45vw'} />
       </Root>
     );
   }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,13 +1,15 @@
-import {Grid, makeStyles, styled} from "@material-ui/core";
+import {Grid, makeStyles, styled, Theme, useMediaQuery, useTheme} from "@material-ui/core";
 import React from "react";
 import ReactGA from "react-ga";
 import {ClientContainer} from "../components/home/desktop/ClientContainer";
 import {companies} from "../constants/companies";
 import {communities} from "../constants/communities";
 import {LeftMargin} from "../components/LeftMargin";
-import {borderStyle} from "../theme/styles";
+import {borderStyle, borderStyles} from "../theme/styles";
 import {RightMargin} from "../components/RightMargin";
 import {HomeTitleBox} from "../components/home/desktop/HomeTitleBox";
+import {HomeTitleBoxMobile} from "../components/home/mobile/HomeTItleBoxMobile";
+import {ClientTabsMobile} from "../components/home/mobile/ClientTabsMobile";
 
 const Root = styled(Grid)({
   margins: 'auto',
@@ -30,16 +32,6 @@ const PageHalf = styled(Grid)({
   borderLeft: borderStyle
 })
 
-const StyledRings = styled('img')({
-  width: '19.125vw',
-  height: '19.063vw',
-  objectFit: 'contain',
-  position: 'absolute',
-  transform: 'scaleY(-1)',
-  bottom: 0,
-  right: 0
-});
-
 const useTitlePositionStyle = makeStyles({
   location: {
     position: 'absolute',
@@ -49,29 +41,68 @@ const useTitlePositionStyle = makeStyles({
   }
 })
 
+const StyledRings = styled('img')({
+  width: '19.125vw',
+  height: '19.063vw',
+  objectFit: 'contain',
+  position: 'absolute',
+  transform: 'scaleY(-1)',
+  bottom: 0,
+  right: 0,
+  zIndex: 0
+});
+
+const useBorders = makeStyles(borderStyles);
+
 export const Home: React.FC = () => {
 
   ReactGA.pageview('/');
 
   const titlePosition = useTitlePositionStyle();
+  const borders = useBorders();
 
-  return (
-    <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
-      <LeftMargin border={borderStyle} height='57.375vw' />
-      <ContentContainer container item spacing={0} direction='row' justify="center" alignItems='flex-start'>
-        <PageHalf item xs={6}>
-          <ClientContainer title={'COMPANIES'} clients={companies} isOnLeft />
-        </PageHalf>
-        <PageHalf item xs={6}>
-          <ClientContainer title={'COMMUNITIES'} clients={communities} />
-        </PageHalf>
-        <HomeTitleBox classes={titlePosition.location}
-          titleTextPrimary={'We build custom'}
-          titleTextSecondary={'Dapps'}
-          subTitleText={'We’ve helped some of Web3’s top projects design, code and ship.'} />
-        <StyledRings src='imgs/concentric-rings-left.svg' alt={'concentric rings flourish'} />
-      </ContentContainer>
-      <RightMargin border={borderStyle} height='57.375vw' longAccentIndex={0}/>
-    </Root>
-  );
+  const theme: Theme = useTheme();
+  const desktop = useMediaQuery(theme.breakpoints.up('lg'));
+
+  if (desktop) {
+    return (
+      <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
+        <LeftMargin border={borderStyle} height='57.375vw' />
+        <ContentContainer container item spacing={0} direction='row' justify="center" alignItems='flex-start'>
+          <PageHalf item xs={6}>
+            <ClientContainer title={'COMPANIES'} clients={companies} isOnLeft />
+          </PageHalf>
+          <PageHalf item xs={6}>
+            <ClientContainer title={'COMMUNITIES'} clients={communities} />
+          </PageHalf>
+          <HomeTitleBox classes={titlePosition.location}
+            titleTextPrimary={'We build custom'}
+            titleTextSecondary={'Dapps'}
+            subTitleText={'We’ve helped some of Web3’s top projects design, code and ship.'} />
+          <StyledRings src='imgs/concentric-rings-left.svg' alt={'concentric rings flourish'} />
+        </ContentContainer>
+        <RightMargin border={borderStyle} height='57.375vw' longAccentIndex={0}/>
+      </Root>
+    );
+  } else {
+    return (
+      <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
+        <LeftMargin border={borderStyle} height='233.45vw' />
+        <ContentContainer container item spacing={0} direction='row' justify="center" alignItems='flex-start' style={{width: '90vw'}}>
+          <HomeTitleBoxMobile
+            titleTextPrimary={'We build custom'}
+            titleTextSecondary={'Dapps'}
+            subTitleText={'We’ve helped some of Web3’s top projects design, code and ship.'}
+            classes={borders.bottomLeftBorder}/>
+          <ClientTabsMobile
+            companiesTitle={'COMPANIES'}
+            communitiesTitle={'COMMUNITIES'}
+            companies={companies}
+            communities={communities}
+            classes={borders.leftBorder}/>
+        </ContentContainer>
+        <RightMargin border={borderStyle} height={'233.45vw'} />
+      </Root>
+    );
+  }
 };


### PR DESCRIPTION
Added draft mobile home page. Closes #77.

Still to fix: the background highlight color of the expanded content needs to also go over the margins, as seen [here](https://app.zeplin.io/project/5fc8757e071b5908d4857503/screen/5fcb086bcd89fa68007b5fb1).