### PR TITLE
Populate about details and fix home sticky bug

### DIFF
--- a/src/components/FooterDesktop.tsx
+++ b/src/components/FooterDesktop.tsx
@@ -4,7 +4,7 @@ import {getBorderStyle} from "../theme/styles";
 import {theme} from "../theme";
 
 
-const COPYRIGHT_TEXT = 'Copyright 2020, dorg.tech';
+const COPYRIGHT_TEXT = '© dOrg, LLC';
 const EMAIL_ICON_PATH = '/imgs/footer/email-icon.svg';
 const GITHUB_ICON_PATH = '/imgs/footer/github-logo.svg';
 const DISCORD_ICON_PATH = '/imgs/footer/discord-logo.svg';

--- a/src/components/FooterMobile.tsx
+++ b/src/components/FooterMobile.tsx
@@ -4,7 +4,7 @@ import {borderStyles} from "../theme/styles";
 import {theme} from "../theme";
 
 
-const COPYRIGHT_TEXT = 'Copyright 2020, dorg.tech';
+const COPYRIGHT_TEXT = '© dOrg, LLC';
 const EMAIL_ICON_PATH = '/imgs/footer/email-icon.svg';
 const GITHUB_ICON_PATH = '/imgs/footer/github-logo.svg';
 const DISCORD_ICON_PATH = '/imgs/footer/discord-logo.svg';

--- a/src/components/about/desktop/StatBox.tsx
+++ b/src/components/about/desktop/StatBox.tsx
@@ -1,8 +1,8 @@
 import React, {useEffect, useState} from 'react'
 import { Box, styled, Typography, Grid } from '@material-ui/core'
-
-import { Stat } from "../../../constants/stats";
 import { theme } from "../../../theme";
+import {Stat} from "../../../constants/stats";
+import {formatStat, getIncrement, getWildNumber} from "../../../utils/statUtils";
 
 const StyledBox = styled(Box)({
   margin: 'auto',
@@ -53,13 +53,6 @@ const StyledIcon = styled('img')({
   float: 'right'
 });
 
-const currencyFormatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  minimumFractionDigits: 0,
-  maximumFractionDigits: 0,
-});
-
 interface Props {
   stat: Stat;
   classes?: string;
@@ -67,49 +60,41 @@ interface Props {
 
 export const StatBox: React.FC<Props> = (props: Props) => {
 
-  const postfix = props.stat.postfix ? props.stat.postfix : '';
-  const end = props.stat.stat;
-  const isCurrency = props.stat.currency
-
-  const formatStat = (num: number) => {
-    if (isCurrency) {
-      return currencyFormatter.format(num) + postfix;
-    } else {
-      return num.toString() + postfix;
-    }
-  }
+  const { title, stat, icon, formatter, postfix } = props.stat
 
   const [wild, setWild] = useState<NodeJS.Timeout | null>(null);
+  const [value, setValue] = useState(0);
+  const increment = getIncrement(stat);
+
   const handleMouseEnter = () => {
     setWild(setInterval(() => {
-      setStat(Math.floor(Math.random() * end));
+      setValue(getWildNumber(stat));
     }, 15));
   };
+
   const handleMouseLeave = () => {
     if (wild) {
       clearInterval(wild);
       setWild(null);
     }
-    setStat(0);
+    setValue(0);
   }
 
-  const [stat, setStat] = useState(0);
-  const increment = Math.ceil(end / 50);
   useEffect(() => {
-    if (stat < end && !wild) {
+    if (value < stat && !wild) {
       setTimeout(() => {
-        const nextStat = Math.min(stat + increment, end);
-        setStat(nextStat);
+        const nextValue = Math.min(value + increment, stat);
+        setValue(nextValue);
       }, 15)
     }
-  }, [stat, end, increment, wild])
+  }, [value, stat, increment, wild])
 
   return (
     <StyledBox className={props.classes} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-      <StyledIcon src={props.stat.icon} alt='icon' />
+      <StyledIcon src={icon} alt='icon' />
       <Grid container direction='column' spacing={0} justify='center' alignItems='center'>
-        <StyledStat>{formatStat(stat)}</StyledStat>
-        <StyledTitle>{props.stat.title}</StyledTitle>
+        <StyledStat>{formatStat(value, postfix, formatter)}</StyledStat>
+        <StyledTitle>{title}</StyledTitle>
       </Grid>
     </StyledBox>
   );

--- a/src/components/about/mobile/StatBoxMobile.tsx
+++ b/src/components/about/mobile/StatBoxMobile.tsx
@@ -1,9 +1,9 @@
 import React, {useEffect, useState} from 'react'
 import { styled, Typography, Grid } from '@material-ui/core'
-
-import { Stat } from "../../../constants/stats";
 import { theme } from "../../../theme";
 import {mobileStatFont} from "../../../theme/styles";
+import {Stat} from "../../../constants/stats";
+import {formatStat, getIncrement} from "../../../utils/statUtils";
 
 const StyledBox = styled(Grid)({
   margin: 'auto',
@@ -58,13 +58,6 @@ const StyledIcon = styled('img')({
   top: '-1vw'
 });
 
-const currencyFormatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  minimumFractionDigits: 0,
-  maximumFractionDigits: 0,
-});
-
 
 interface Props {
   stat: Stat;
@@ -73,42 +66,33 @@ interface Props {
 
 export const StatBoxMobile: React.FC<Props> = (props: Props) => {
 
-  const postfix = props.stat.postfix ? props.stat.postfix : '';
-  const end = props.stat.stat;
-  const isCurrency = props.stat.currency
+  const { title, stat, icon, formatter, postfix } = props.stat
 
-  const formatStat = (num: number) => {
-    if (isCurrency) {
-      return currencyFormatter.format(num) + postfix;
-    } else {
-      return num.toString() + postfix;
-    }
-  }
+  const [value, setValue] = useState(0);
+  const increment = getIncrement(stat);
 
-  const [stat, setStat] = useState(0);
-  const increment = Math.ceil(end / 50);
   useEffect(() => {
-    if (stat < end) {
+    if (value < stat) {
       setTimeout(() => {
-        const nextStat = Math.min(stat + increment, end);
-        setStat(nextStat);
+        const nextValue = Math.min(value + increment, stat);
+        setValue(nextValue);
       }, 15)
     }
-  }, [stat, end, increment])
+  }, [value, stat, increment])
 
-  const handleTouch = () => setStat(0);
+  const handleTouch = () => setValue(0);
 
   return (
     <StyledBox className={props.classes} container direction='row' spacing={0} justify='space-between' alignItems='center'
       onTouchEnd={handleTouch}>
       <Grid item xs={6}>
-        <StyledStat>{formatStat(stat)}</StyledStat>
+        <StyledStat>{formatStat(value, postfix, formatter)}</StyledStat>
       </Grid>
       <Grid item xs={6}>
-        <StyledIcon src={props.stat.icon} alt='icon' />
+        <StyledIcon src={icon} alt='icon' />
       </Grid>
       <Grid item xs={12}>
-        <StyledTitle>{props.stat.title}</StyledTitle>
+        <StyledTitle>{title}</StyledTitle>
       </Grid>
     </StyledBox>
   );

--- a/src/components/home/desktop/ClientContainer.tsx
+++ b/src/components/home/desktop/ClientContainer.tsx
@@ -76,7 +76,7 @@ export const ClientContainer: React.FC<Props> = (props: Props) => {
     }
   }
 
-  const handleClick = (element: JSX.Element, name?: string, ) => {
+  const handleClick = (element: JSX.Element, name?: string) => {
     setSticky(name);
     setCaseStudy(element);
   }

--- a/src/components/home/desktop/ClientItem.tsx
+++ b/src/components/home/desktop/ClientItem.tsx
@@ -4,6 +4,7 @@ import { theme } from "../../../theme";
 import {Client} from "../../../constants/clients";
 import {ProjectHoverRight} from "./ProjectHover/ProjectHoverRight";
 import {ProjectHoverLeft} from "./ProjectHover/ProjectHoverLeft";
+import {useDebounce} from "../../../utils/hooks";
 
 
 const StyledGrid = styled(Grid)({
@@ -50,8 +51,9 @@ export const ClientItem: React.FC<Props> = (props: Props) => {
 
   const classes: string = props.classes ? props.classes : ''
   const isSticky = props.stickyItem === props.client.name;
+  const debouncedIsSticky = useDebounce(isSticky, 50);
   const [isHover, setIsHover] = useState(false);
-  const isHighlight = isSticky || isHover;
+  const isHighlight = debouncedIsSticky || isHover;
 
   // handle hover-dependent state
   const handleMouseEnter = () => {
@@ -68,7 +70,7 @@ export const ClientItem: React.FC<Props> = (props: Props) => {
 
   // make sticky on click
   const handleClick = () => {
-    if (isSticky) {
+    if (debouncedIsSticky) {
       props.onClick?.(<div/>)
     } else {
       const popup = props.isOnLeft ?
@@ -94,8 +96,8 @@ export const ClientItem: React.FC<Props> = (props: Props) => {
       background: isHighlight ? props.client.highlightColor : ''
     },
     sticky: {
-      boxShadow: isSticky ? '0 0.5625vw #1AAF71' : '',
-      transform: isSticky ? 'translateY(-0.5625vw)' : ''
+      boxShadow: debouncedIsSticky ? '0 0.5625vw #1AAF71' : '',
+      transform: debouncedIsSticky ? 'translateY(-0.5625vw)' : ''
     },
     icon: {
       filter: iconColor(isHighlight),

--- a/src/constants/stats.ts
+++ b/src/constants/stats.ts
@@ -1,6 +1,5 @@
 import {getMonthsTogether} from "../utils/statUtils";
 
-
 export interface Stat {
   title: string;
   stat: number;
@@ -59,7 +58,7 @@ export const stats: Stats = {
   },
   lifetime: {
     title: 'MONTHS TOGETHER',
-    stat: getMonthsTogether(new Date(), true),
+    stat: getMonthsTogether(new Date()),
     icon: 'imgs/calendar-icon.svg'
   },
   raised: {
@@ -97,7 +96,7 @@ export const statsMobile: Stats = {
   },
   lifetime: {
     title: 'Months together',
-    stat: getMonthsTogether(new Date(), true),
+    stat: getMonthsTogether(new Date()),
     icon: 'imgs/calendar-icon.svg'
   },
   raised: {

--- a/src/constants/stats.ts
+++ b/src/constants/stats.ts
@@ -58,7 +58,7 @@ export const stats: Stats = {
   },
   lifetime: {
     title: 'MONTHS TOGETHER',
-    stat: getMonthsTogether(new Date()),
+    stat: getMonthsTogether(new Date(), true),
     icon: 'imgs/calendar-icon.svg'
   },
   raised: {
@@ -96,7 +96,7 @@ export const statsMobile: Stats = {
   },
   lifetime: {
     title: 'Months together',
-    stat: getMonthsTogether(new Date()),
+    stat: getMonthsTogether(new Date(), true),
     icon: 'imgs/calendar-icon.svg'
   },
   raised: {

--- a/src/constants/stats.ts
+++ b/src/constants/stats.ts
@@ -1,5 +1,6 @@
 import {getMonthsTogether} from "../utils/statUtils";
 
+
 export interface Stat {
   title: string;
   stat: number;

--- a/src/constants/stats.ts
+++ b/src/constants/stats.ts
@@ -1,8 +1,10 @@
+import {getMonthsTogether} from "../utils/statUtils";
+
 export interface Stat {
   title: string;
   stat: number;
   icon: string;
-  currency?: boolean;
+  formatter?: Intl.NumberFormat
   postfix?: string;
 }
 
@@ -15,16 +17,31 @@ export interface Stats {
   raised: Readonly<Stat>;
 }
 
+const tvlFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+const raisedFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
 export const stats: Stats = {
   projects: {
     title: 'PROJECTS SHIPPED',
-    stat: 25,
+    stat: 40,
+    postfix: '+',
     icon: 'imgs/bracketed-dot-icon.svg'
   },
   tvl: {
     title: 'TVL IN OUR PRODUCTS',
-    stat: 2,
-    currency: true,
+    stat: 3.5,
+    formatter: tvlFormatter,
     postfix: 'B+',
     icon: 'imgs/circle-slice-icon.svg'
   },
@@ -36,18 +53,18 @@ export const stats: Stats = {
   },
   builders: {
     title: 'ACTIVE BUILDERS',
-    stat: 47,
+    stat: 35,
     icon: 'imgs/people-icon.svg'
   },
   lifetime: {
     title: 'MONTHS TOGETHER',
-    stat: 24,
+    stat: getMonthsTogether(new Date()),
     icon: 'imgs/calendar-icon.svg'
   },
   raised: {
     title: 'FUNDING RAISED',
     stat: 0,
-    currency: true,
+    formatter: raisedFormatter,
     icon: 'imgs/dollar-sign-icon.svg'
   }
 }
@@ -55,14 +72,15 @@ export const stats: Stats = {
 export const statsMobile: Stats = {
   projects: {
     title: 'Projects shipped',
-    stat: 25,
+    stat: 40,
+    postfix: '+',
     icon: 'imgs/bracketed-dot-icon.svg'
   },
   tvl: {
     title: 'TVL in our products',
-    stat: 999,
-    currency: true,
-    postfix: 'M+',
+    stat: 3.5,
+    formatter: tvlFormatter,
+    postfix: 'B+',
     icon: 'imgs/circle-slice-icon.svg'
   },
   clients: {
@@ -73,18 +91,18 @@ export const statsMobile: Stats = {
   },
   builders: {
     title: 'Active builders',
-    stat: 30,
+    stat: 35,
     icon: 'imgs/people-icon.svg'
   },
   lifetime: {
     title: 'Months together',
-    stat: 18,
+    stat: getMonthsTogether(new Date()),
     icon: 'imgs/calendar-icon.svg'
   },
   raised: {
     title: 'Funding raised',
     stat: 0,
-    currency: true,
+    formatter: raisedFormatter,
     icon: 'imgs/dollar-sign-icon.svg'
   }
 }

--- a/src/constants/stats.ts
+++ b/src/constants/stats.ts
@@ -1,6 +1,5 @@
 import {getMonthsTogether} from "../utils/statUtils";
 
-
 export interface Stat {
   title: string;
   stat: number;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -74,8 +74,7 @@ export const About: React.FC = () => {
 
   const {projects, tvl, clients, builders, lifetime, raised} = desktop ? stats : statsMobile;
   // request members from server and update num builders
-  const numBuilders = useMembers().length;
-  const dynamicBuilders = {...builders, stat: numBuilders};
+  const dynamicBuilders = {...builders, stat: useMembers().length};
   const statsList = [projects, tvl, clients, dynamicBuilders, lifetime, raised];
 
   if (desktop) {

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -22,7 +22,6 @@ import {PitchBoxMobile} from "../components/about/mobile/PitchBoxMobile";
 import {CloseBoxMobile} from "../components/about/mobile/CloseBoxMobile";
 import {useMembers} from "../utils/hooks";
 
-
 // strings
 const ABOUT_TITLE = 'We are a full-stack Web3 development collective.';
 const PITCHES_TITLE = 'What’s it like to work with us?';

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -20,6 +20,7 @@ import {StatBoxMobile} from "../components/about/mobile/StatBoxMobile";
 import {PitchTitleBoxMobile} from "../components/about/mobile/PitchTitleBoxMobile";
 import {PitchBoxMobile} from "../components/about/mobile/PitchBoxMobile";
 import {CloseBoxMobile} from "../components/about/mobile/CloseBoxMobile";
+import {useMembers} from "../utils/hooks";
 
 // strings
 const ABOUT_TITLE = 'We are a full-stack Web3 development collective.';
@@ -71,6 +72,12 @@ export const About: React.FC = () => {
   const theme: Theme = useTheme();
   const desktop = useMediaQuery(theme.breakpoints.up('lg'));
 
+  const {projects, tvl, clients, builders, lifetime, raised} = desktop ? stats : statsMobile;
+  // request members from server and update num builders
+  const numBuilders = useMembers().length;
+  const dynamicBuilders = {...builders, stat: numBuilders};
+  const statsList = [projects, tvl, clients, dynamicBuilders, lifetime, raised];
+
   if (desktop) {
     return (
       <Root container spacing={0} direction='row' justify="flex-start" alignItems='flex-start'>
@@ -82,7 +89,7 @@ export const About: React.FC = () => {
             <AboutTitleBox text={PITCHES_TITLE} classes={borders.bottomBorder} />
           </Grid>
           <StatsContainer container item xs={6} spacing={0} justify="center">
-            {Object.values(stats).map((stat: Stat, index: number) => (
+            {statsList.map((stat: Stat, index: number) => (
               <Grid item xs={6} key={`stat-${index}`}>
                 <StatBox stat={stat} classes={borders.bottomLeftBorder} />
               </Grid>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -22,6 +22,7 @@ import {PitchBoxMobile} from "../components/about/mobile/PitchBoxMobile";
 import {CloseBoxMobile} from "../components/about/mobile/CloseBoxMobile";
 import {useMembers} from "../utils/hooks";
 
+
 // strings
 const ABOUT_TITLE = 'We are a full-stack Web3 development collective.';
 const PITCHES_TITLE = 'What’s it like to work with us?';

--- a/src/pages/Careers.tsx
+++ b/src/pages/Careers.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from "react";
+import React from "react";
 import ReactGA from "react-ga";
 import {Grid, makeStyles, styled, Theme, useMediaQuery, useTheme} from "@material-ui/core";
 import { Perk, perks } from "../constants/perks";
@@ -23,7 +23,7 @@ import {MeetBuildersTitleBoxMobile} from "../components/careers/mobile/MeetBuild
 import {ProfileWheelMobile} from "../components/careers/mobile/portfolio_section/ProfileWheelMobile";
 import {TestimonialSectionMobile} from "../components/careers/mobile/testimonial_section/TestimonialSectionMobile";
 import {CurrentOpeningSectionMobile} from "../components/careers/mobile/openings_section/CurrentOpeningSectionMobile";
-import {getMembers} from "../utils/network";
+import {useMembers} from "../utils/hooks";
 
 const CAREERS_TITLE_PRIMARY = 'Discover a new way to';
 const CAREERS_TITLE_SECONDARY = ['work', 'learn', 'grow', 'build'];
@@ -58,13 +58,7 @@ export const Careers: React.FC = () => {
   ReactGA.pageview('/careers');
 
   // request members from server
-  const [members, setMembers] = useState<Member[]>([]);
-  useEffect(() => {
-    if (members.length > 0) return;
-    getMembers()
-      .then(members => setMembers(members))
-      .catch(error => console.log(error))
-  }, [members])
+  const members: Member[] = useMembers(); // eslint-disable-line
 
   const navigationToActivation = () => window.location.assign(externalLinks.activation.path);
   const borders = useBorders();

--- a/src/utils/hooks.tsx
+++ b/src/utils/hooks.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react'
+import {Member} from "../constants/members";
+import {getMembers} from "./network";
 
 
+// debounce a value
 function useDebounce<T>(value: T, delay?: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value)
 
@@ -17,7 +20,7 @@ export interface WindowSize {
   width: number;
   height: number;
 }
-
+// get window dimensions dynamically
 function useWindowSize(): WindowSize {
   const [dimensions, setDimensions] = useState({
     height: window.innerHeight,
@@ -41,4 +44,16 @@ function useWindowSize(): WindowSize {
   return dimensions;
 }
 
-export {useWindowSize, useDebounce}
+// get members from server and return member array
+function useMembers(): Member[] {
+  const [members, setMembers] = useState<Member[]>([]);
+  useEffect(() => {
+    if (members.length > 0) return;
+    getMembers()
+      .then(members => setMembers(members))
+      .catch(error => console.log(error))
+  }, [members])
+  return members
+}
+
+export {useWindowSize, useDebounce, useMembers}

--- a/src/utils/statUtils.ts
+++ b/src/utils/statUtils.ts
@@ -25,7 +25,7 @@ export const getWildNumber = (stat: number): number => {
 }
 
 // based on solution found at https://stackoverflow.com/questions/2536379/difference-in-months-between-two-dates-in-javascript
-export function getMonthsTogether(endDate: Date, roundUpFractionalMonths=false): number {
+export function getMonthsTogether(endDate: Date, roundUpFractionalMonths=true): number {
   const startDate = new Date('Jan 29, 2019');
 
   //Calculate the differences between the start and end dates

--- a/src/utils/statUtils.ts
+++ b/src/utils/statUtils.ts
@@ -1,0 +1,48 @@
+
+export const formatStat = (num: number, postfix?: string, formatter?: Intl.NumberFormat): string => {
+  const post = postfix ? postfix : ''
+  if (formatter) {
+    return formatter.format(num) + post;
+  } else {
+    return num.toString() + post;
+  }
+}
+
+export const getIncrement = (stat: number): number => {
+  if (stat % 1 === 0) {
+    return Math.ceil(stat / 50);
+  } else {
+    return Math.round( 10 * stat / 50) / 10;
+  }
+}
+
+export const getWildNumber = (stat: number): number => {
+  if (stat % 1 === 0) {
+    return Math.floor(Math.random() * stat);
+  } else {
+    return Math.round(Math.random() * stat * 10) / 10;
+  }
+}
+
+// based on solution found at https://stackoverflow.com/questions/2536379/difference-in-months-between-two-dates-in-javascript
+export function getMonthsTogether(endDate: Date, roundUpFractionalMonths=false): number {
+  const startDate = new Date('Jan 29, 2019');
+
+  //Calculate the differences between the start and end dates
+  const yearsDifference = endDate.getFullYear() - startDate.getFullYear();
+  const monthsDifference = endDate.getMonth() - startDate.getMonth();
+  const daysDifference = endDate.getDate() - startDate.getDate();
+
+  let monthCorrection = 0;
+  //If roundUpFractionalMonths is true, check if an extra month needs to be added from rounding up.
+  //The difference is done by ceiling (round up), e.g. 3 months and 1 day will be 4 months.
+  if (roundUpFractionalMonths && daysDifference > 0) {
+    monthCorrection = 1;
+  }
+  //If the day difference between the two months is negative, the last month is not a whole month.
+  else if (!roundUpFractionalMonths && daysDifference < 0) {
+    monthCorrection = -1;
+  }
+
+  return yearsDifference * 12 + monthsDifference + monthCorrection;
+}


### PR DESCRIPTION
Added dynamic calculation of number of active builders and number of months together. Other About page statistics are hard-coded but updated as of now.

Improved stat animation.

Fixed bug on home page where clicking an item that was sticky would make it unsticky then immediately make it sticky again.

Changed copyright text in footer.

Closes #119. Closes #137.