### PR TITLE
revised fix for sticky item bug on home page

### DIFF
--- a/src/components/careers/desktop/testimonial_section/TestimonialCarousel.tsx
+++ b/src/components/careers/desktop/testimonial_section/TestimonialCarousel.tsx
@@ -41,7 +41,11 @@ export const TestimonialCarousel: React.FC<Props> = (props: Props) => {
 
   return (
     <Box className={props.classes} style={{width: '60.625vw', height: '21.25vw', border: props.border}}>
-      <Carousel fullHeightHover interval={6000} timeout={{appear: 0, enter: 0, exit: 0}}
+      <Carousel
+        fullHeightHover
+        interval={6000}
+        timeout={{appear: 0, enter: 0, exit: 0}}
+        navButtonsAlwaysVisible
         className={carouselStyles.root}
         indicatorProps={{className: carouselStyles.indicator, style: {}}}
         activeIndicatorProps={{className: carouselStyles.activeIndicator, style: {}}}

--- a/src/components/careers/mobile/testimonial_section/TestimonialCarouselMobile.tsx
+++ b/src/components/careers/mobile/testimonial_section/TestimonialCarouselMobile.tsx
@@ -41,7 +41,11 @@ export const TestimonialCarouselMobile: React.FC<Props> = (props: Props) => {
 
   return (
     <Box className={props.classes} style={{width: '100%', height: '96.5vw', borderTop: props.border, borderBottom: props.border}}>
-      <Carousel fullHeightHover interval={6000} timeout={{appear: 0, enter: 0, exit: 0}}
+      <Carousel
+        fullHeightHover
+        interval={6000}
+        timeout={{appear: 0, enter: 0, exit: 0}}
+        navButtonsAlwaysVisible
         className={carouselStyles.root}
         indicatorProps={{className: carouselStyles.indicator, style: {}}}
         activeIndicatorProps={{className: carouselStyles.activeIndicator, style: {}}}

--- a/src/components/home/desktop/ClientContainer.tsx
+++ b/src/components/home/desktop/ClientContainer.tsx
@@ -104,7 +104,7 @@ export const ClientContainer: React.FC<Props> = (props: Props) => {
         </ScrollContainer>
       </StyledGrid>
       <ProjectView id='project-view' style={{right: props.isOnLeft ? '-7.5vw' : '42.5vw'}}>
-        <ClickAwayListener onClickAway={(e) => handleClickAway(e)} mouseEvent={'onMouseDown'}>
+        <ClickAwayListener onClickAway={(e) => handleClickAway(e)} mouseEvent={'onClick'}>
           <div>
             {caseStudy}
           </div>

--- a/src/components/home/desktop/ClientItem.tsx
+++ b/src/components/home/desktop/ClientItem.tsx
@@ -51,7 +51,7 @@ export const ClientItem: React.FC<Props> = (props: Props) => {
 
   const classes: string = props.classes ? props.classes : ''
   const isSticky = props.stickyItem === props.client.name;
-  const debouncedIsSticky = useDebounce(isSticky, 100);
+  const debouncedIsSticky = useDebounce(isSticky, 50);
   const [isHover, setIsHover] = useState(false);
   const isHighlight = debouncedIsSticky || isHover;
 

--- a/src/components/home/desktop/ClientItem.tsx
+++ b/src/components/home/desktop/ClientItem.tsx
@@ -51,7 +51,7 @@ export const ClientItem: React.FC<Props> = (props: Props) => {
 
   const classes: string = props.classes ? props.classes : ''
   const isSticky = props.stickyItem === props.client.name;
-  const debouncedIsSticky = useDebounce(isSticky, 50);
+  const debouncedIsSticky = useDebounce(isSticky, 100);
   const [isHover, setIsHover] = useState(false);
   const isHighlight = debouncedIsSticky || isHover;
 
@@ -113,7 +113,7 @@ export const ClientItem: React.FC<Props> = (props: Props) => {
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onMouseOver={handleMouseOver}
-      onClick={handleClick}>
+      onClickCapture={handleClick}>
       <Grid item>
         <ClientIcon src={props.client.icon} alt='client icon' className={styles.icon} />
       </Grid>


### PR DESCRIPTION
Improved fix for issue where clicking an item on the home page to make it unsticky would immediatealy make it stickky again. Also made arrows in testimonials carousel always visible (requested in issue #139)..