### PR TITLE
iOS overscroll bug fix

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,14 @@
 @import url('https://fonts.googleapis.com/css2?family=Spartan:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 
+html {
+  height  : 100%;
+  overflow: hidden;
+  position: relative;
+}
+
 body {
   margin: 0;
+  height  : 100%;
+  overflow: auto;
+  position: relative;
 }

--- a/src/components/careers/desktop/portfolio_section/ProfileWheel.tsx
+++ b/src/components/careers/desktop/portfolio_section/ProfileWheel.tsx
@@ -104,7 +104,7 @@ export const ProfileWheel: React.FC<Props> = (props: Props) => {
     const scrollbar = scrollRef.current;
     if (isScrolling && scrollbar) {
       const startScrollX = scrollbar.scrollLeft
-      scrollbar.scrollLeft += clientX - e.clientX;
+      scrollbar.scrollLeft += 2 * (clientX - e.clientX);
       setClientX(e.clientX)
       // give appearance of infinite scroll
       if (scrollbar.scrollLeft === scrollbar.scrollWidth - debouncedWindowSize.width && startScrollX < scrollbar.scrollLeft) {


### PR DESCRIPTION
Solved bug by preventing overscrolling on iOS. Closes #135.

I also smuggled in an unrelated change to this PR: I doubled the responsiveness of the drag-to-scroll action for the builder profile slide show on the careers page.