### PR TITLE
adding the GA tag again

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,17 @@
     <meta name="twitter:image" content="%PUBLIC_URL%/imgs/seo/dorg-logo-twitter.png"/>
     <meta name="twitter:image:width" content="2998" />
     <meta name="twitter:image:height" content="1570" />
+    
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-5XSH9JXBH1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
+      gtag('config', 'G-5XSH9JXBH1');
+    </script>
+    
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
dunno why this tag was removed back in april, probably during the v2 refactor. we were peaking on interest and stopped logging.

please someone run this locally to make sure it's working, but it should be able to run properly