### PR TITLE
fixes bug where contact form label colors were wrong

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "homepage": "https://dorg.tech/",
   "scripts": {
-    "start": "yarn node src/server/server.js keyrogdxKlTJktyef",
+    "start": "yarn node src/server/server.js",
     "dev": "react-scripts start",
     "build": "CI=false react-scripts build && echo dorg.tech > build/CNAME",
     "test": "react-scripts test",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "homepage": "https://dorg.tech/",
   "scripts": {
-    "start": "yarn node src/server/server.js",
+    "start": "yarn node src/server/server.js keyrogdxKlTJktyef",
     "dev": "react-scripts start",
     "build": "CI=false react-scripts build && echo dorg.tech > build/CNAME",
     "test": "react-scripts test",

--- a/src/components/contact/desktop/ContactForm.tsx
+++ b/src/components/contact/desktop/ContactForm.tsx
@@ -301,7 +301,7 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
               onChange={handleEmailChange}
               InputProps={{disableUnderline: true}}
               inputRef={register({required: true, maxLength: MAX_EMAIL_LENGTH, pattern: EMAIL_PATTERN})}
-              className={unfocusedLabelColor(name)} />
+              className={unfocusedLabelColor(email)} />
           </Grid>
           {debouncedErrors.email?.type === "required" && <StyledError>{ERROR_EMAIL_REQUIRED}</StyledError>}
           {debouncedErrors.email?.type === "maxLength" && <StyledError>{ERROR_EXCEEDS_LENGTH(email.length, MAX_EMAIL_LENGTH)}</StyledError>}
@@ -318,7 +318,7 @@ export const ContactForm: React.FC<Props> = (props: Props) => {
               InputProps={{disableUnderline: true}}
               inputRef={register({required: true, maxLength: MAX_MESSAGE_LENGTH})}
               style={{height: 'inherit'}}
-              className={unfocusedLabelColor(name)} />
+              className={unfocusedLabelColor(message)} />
           </Grid>
           {debouncedErrors.message?.type === "required" && <StyledError>{ERROR_MESSAGE_REQUIRED}</StyledError>}
           {debouncedErrors.message?.type === "maxLength" && <StyledError>{ERROR_EXCEEDS_LENGTH(message.length, MAX_MESSAGE_LENGTH)}</StyledError>}


### PR DESCRIPTION
While trying to find the cause of Issue #257, I noticed the contact form label colors for "Email" and "Message" were turning green when the "Name" box contained text. They were not turning green when they contained text. They should turn green when and only when there is text in their respective boxes. Only the "Name" box was behaving correctly.

<img width="606" alt="Screen Shot 2021-11-07 at 2 02 54 PM" src="https://user-images.githubusercontent.com/39842820/140658307-424e8cc1-c807-4bd8-9175-93bc1c6d99e4.png">

<img width="604" alt="Screen Shot 2021-11-07 at 2 02 43 PM" src="https://user-images.githubusercontent.com/39842820/140658306-927a3d1b-cb10-4d5c-8ac4-ed638450876c.png">

